### PR TITLE
Calendar back

### DIFF
--- a/js/appRoutes.js
+++ b/js/appRoutes.js
@@ -54,6 +54,15 @@ angular.module('appRoutes', []).config(['$routeProvider', '$locationProvider', f
         title: 'View Event Details'
     });
 
+    $routeProvider.when('/games-events', {
+        templateUrl: 'views/games-events.html',
+        controller: 'GamesEventsCtrl',
+        caseInsensitiveMatch: true,
+        reloadOnSearch: false,
+        activeTab: 'games-events',
+        title: 'Games Events',
+    });
+
     $routeProvider.when('/logout', {
         templateUrl: 'views/login.html',
         controller: 'LoginCtrl'

--- a/js/appRoutes.js
+++ b/js/appRoutes.js
@@ -58,6 +58,8 @@ angular.module('appRoutes', []).config(['$routeProvider', '$locationProvider', f
         templateUrl: 'views/games-events.html',
         controller: 'GamesEventsCtrl',
         caseInsensitiveMatch: true,
+        // This is necesary as else anytime you update a search() parameter, it causes the full
+        // page to reload which is ugly
         reloadOnSearch: false,
         activeTab: 'games-events',
         title: 'Games Events',

--- a/js/appRoutes.js
+++ b/js/appRoutes.js
@@ -58,7 +58,7 @@ angular.module('appRoutes', []).config(['$routeProvider', '$locationProvider', f
         templateUrl: 'views/games-events.html',
         controller: 'GamesEventsCtrl',
         caseInsensitiveMatch: true,
-        //reloadOnSearch: false,
+        reloadOnSearch: false,
         activeTab: 'games-events',
         title: 'Games Events',
     });

--- a/js/appRoutes.js
+++ b/js/appRoutes.js
@@ -58,7 +58,7 @@ angular.module('appRoutes', []).config(['$routeProvider', '$locationProvider', f
         templateUrl: 'views/games-events.html',
         controller: 'GamesEventsCtrl',
         caseInsensitiveMatch: true,
-        reloadOnSearch: false,
+        //reloadOnSearch: false,
         activeTab: 'games-events',
         title: 'Games Events',
     });

--- a/js/controllers/EventCtrl.js
+++ b/js/controllers/EventCtrl.js
@@ -1,5 +1,9 @@
 var ctrl_name = 'EventCtrl';
-angular.module(ctrl_name, []).controller(ctrl_name, ['$scope', '$http', '$location', '$route', '$routeParams', 'AuthService', function($scope, $http, $location, $route, $routeParams, AuthService) {
+angular.module(ctrl_name, []).controller(ctrl_name, ['$scope', '$http', '$location', '$route', '$routeParams', 'AuthService', '$window', function($scope, $http, $location, $route, $routeParams, AuthService, $window) {
+    $scope.back = function() {
+        $window.history.back();
+    };
+
     $scope.load = function() {
         $scope.loaded = false;
         AuthService.isAdmin().then(function (response) {

--- a/js/controllers/EventCtrl.js
+++ b/js/controllers/EventCtrl.js
@@ -1,8 +1,6 @@
 var ctrl_name = 'EventCtrl';
 angular.module(ctrl_name, []).controller(ctrl_name, ['$scope', '$http', '$location', '$route', '$routeParams', 'AuthService', '$window', function($scope, $http, $location, $route, $routeParams, AuthService, $window) {
-    $scope.back = function() {
-        $window.history.back();
-    };
+    $scope.calendarView = $location.search()['calendarView'] || 'month';
 
     $scope.load = function() {
         $scope.loaded = false;

--- a/js/controllers/GameCtrl.js
+++ b/js/controllers/GameCtrl.js
@@ -1,5 +1,9 @@
 var ctrl_name = 'GameCtrl';
-angular.module(ctrl_name, []).controller(ctrl_name, ['$scope', '$http', '$location', '$route', '$routeParams', 'AuthService', function($scope, $http, $location, $route, $routeParams, AuthService) {
+angular.module(ctrl_name, []).controller(ctrl_name, ['$scope', '$http', '$location', '$route', '$routeParams', 'AuthService', '$window', function($scope, $http, $location, $route, $routeParams, AuthService, $window) {
+    $scope.back = function() {
+        $window.history.back();
+    };
+
     $scope.load = function() {
         $scope.loaded = false;
         AuthService.isAdmin().then(function (response) {

--- a/js/controllers/GameCtrl.js
+++ b/js/controllers/GameCtrl.js
@@ -1,8 +1,6 @@
 var ctrl_name = 'GameCtrl';
 angular.module(ctrl_name, []).controller(ctrl_name, ['$scope', '$http', '$location', '$route', '$routeParams', 'AuthService', '$window', function($scope, $http, $location, $route, $routeParams, AuthService, $window) {
-    $scope.back = function() {
-        $window.history.back();
-    };
+    $scope.calendarView = $location.search()['calendarView'] || 'month';
 
     $scope.load = function() {
         $scope.loaded = false;

--- a/js/controllers/GamesEventsCtrl.js
+++ b/js/controllers/GamesEventsCtrl.js
@@ -11,7 +11,7 @@ angular.module('GamesEventsCtrl', ['mwl.calendar', 'ui.bootstrap', 'ngAnimate'])
         $scope.admin = response.admin === '1';
     });
 
-    $scope.calendarView = 'month';
+    $scope.calendarView = $location.search()['calendarView'] || 'month';
 
     if ($location.search()['viewDate']) {
         $scope.viewDate = new Date($location.search()['viewDate']);
@@ -100,6 +100,10 @@ angular.module('GamesEventsCtrl', ['mwl.calendar', 'ui.bootstrap', 'ngAnimate'])
         $scope.updateDate = function() {
             $location.search('viewDate', $scope.viewDate.getFullYear() + "-" + ($scope.viewDate.getMonth()+1) + "-" + $scope.viewDate.getDate());
         };
+
+        $scope.updateView = function() {
+            $location.search('calendarView', $scope.calendarView);
+        }
 
         $scope.addEvent = function() {
             $scope.events.push({

--- a/js/controllers/GamesEventsCtrl.js
+++ b/js/controllers/GamesEventsCtrl.js
@@ -1,3 +1,9 @@
+angular.module('mwl.calendar').controller('MwlDateModifierCtrl2', function($element, $attrs, $scope, moment) {
+    var vm = this;
+    function onClick() {
+        console.log('click');
+    }
+});
 
 angular.module('GamesEventsCtrl', ['mwl.calendar', 'ui.bootstrap', 'ngAnimate']).controller('GamesEventsCtrl', ['moment', 'calendarConfig', '$http', '$scope', 'AuthService', '$q', '$location', function(moment, calendarConfig, $http, $scope, AuthService, $q, $location) {
     // TO the next developer: good luck. You're probably screwed. God bless
@@ -6,7 +12,13 @@ angular.module('GamesEventsCtrl', ['mwl.calendar', 'ui.bootstrap', 'ngAnimate'])
     });
 
     $scope.calendarView = 'month';
-    $scope.viewDate = new Date();
+
+    if ($location.search()['viewDate']) {
+        $scope.viewDate = new Date($location.search()['viewDate']);
+    }
+    else {
+        $scope.viewDate = new Date();
+    }
     $scope.events = [];
 
     var hold = AuthService.isAdmin();
@@ -84,6 +96,10 @@ angular.module('GamesEventsCtrl', ['mwl.calendar', 'ui.bootstrap', 'ngAnimate'])
 
 
         $scope.cellIsOpen = false;
+
+        $scope.updateDate = function() {
+            $location.search('viewDate', $scope.viewDate.getFullYear() + "-" + ($scope.viewDate.getMonth()+1) + "-" + $scope.viewDate.getDate());
+        };
 
         $scope.addEvent = function() {
             $scope.events.push({

--- a/js/controllers/GamesEventsCtrl.js
+++ b/js/controllers/GamesEventsCtrl.js
@@ -1,11 +1,4 @@
-angular.module('mwl.calendar').controller('MwlDateModifierCtrl2', function($element, $attrs, $scope, moment) {
-    var vm = this;
-    function onClick() {
-        console.log('click');
-    }
-});
-
-angular.module('GamesEventsCtrl', ['mwl.calendar', 'ui.bootstrap', 'ngAnimate']).controller('GamesEventsCtrl', ['moment', 'calendarConfig', '$http', '$scope', 'AuthService', '$q', '$location', function(moment, calendarConfig, $http, $scope, AuthService, $q, $location) {
+angular.module('GamesEventsCtrl', ['mwl.calendar', 'ui.bootstrap', 'ngAnimate']).controller('GamesEventsCtrl', ['moment', 'calendarConfig', '$http', '$scope', 'AuthService', '$q', '$location', '$window', function(moment, calendarConfig, $http, $scope, AuthService, $q, $location, $window) {
     // TO the next developer: good luck. You're probably screwed. God bless
     AuthService.isAdmin().then(function (response) {
         $scope.admin = response.admin === '1';

--- a/js/controllers/GamesEventsCtrl.js
+++ b/js/controllers/GamesEventsCtrl.js
@@ -8,6 +8,7 @@ angular.module('GamesEventsCtrl', ['mwl.calendar', 'ui.bootstrap', 'ngAnimate'])
         $scope.admin = response.admin === '1';
     });
 
+    // Set an initial value so that if we go to /#/
     $scope.initialView = false;
     $scope.initialDate = false;
     $scope.calendarView = $location.search()['calendarView'] || 'month';
@@ -41,6 +42,12 @@ angular.module('GamesEventsCtrl', ['mwl.calendar', 'ui.bootstrap', 'ngAnimate'])
         $scope.initialView = true;
     });
 
+    // This implements the ability to manually go to a viewDate/calendarView and have that
+    // update the page while having the reloadOnSearch be false. This detects any
+    // change in the route/URL of the page you're detecting, whether done by the user
+    // manually or via updating the $location.search() variable, and discards the
+    // trigger done by the latter as it'll match the scored values in the $scope unlike
+    // the former
     $scope.$on('$routeUpdate', function() {
         if ($location.search()['viewDate']) {
             var viewDate = $location.search()['viewDate'].split('-');
@@ -148,7 +155,7 @@ angular.module('GamesEventsCtrl', ['mwl.calendar', 'ui.bootstrap', 'ngAnimate'])
             else {
                 url += 'event/';
             }
-            $location.url(url + event.dbId);
+            $location.url(url + event.dbId + '?calendarView=' + $scope.calendarView);
         };
 
         $scope.eventEdited = function(event) {

--- a/js/controllers/MainCtrl.js
+++ b/js/controllers/MainCtrl.js
@@ -191,11 +191,11 @@ angular.module('MainCtrl', []).controller('MainCtrl', ['$rootScope', '$scope', '
         for (var i = 0; i < $scope.memberNavbar.length; i++) {
             if ($scope.memberNavbar[i].isDropdown) {
                 for (var j = 0; j < $scope.memberNavbar[i].dropdownOptions.length; j++) {
-                    if ("/" + $scope.memberNavbar[i].dropdownOptions[j].page === currentPage && currentPage !== "/home") {
+                    if (currentPage.startsWith("/" + $scope.memberNavbar[i].dropdownOptions[j].page) && currentPage !== "/home") {
                         return true;
                     }
                 }
-            } else if ("/" + $scope.memberNavbar[i].page === currentPage && currentPage !== "/home") {
+            } else if (currentPage.startsWith("/" + $scope.memberNavbar[i].page) && currentPage !== "/home") {
                 return true;
             }
         }

--- a/views/event.html
+++ b/views/event.html
@@ -2,7 +2,7 @@
     <div class="container">
         <div class="row">
             <div class="col-xs-1">
-                <a class="btn btn-sm btn-default" href="#/games-events">
+                <a class="btn btn-sm btn-default" ng-click="back()">
                     <span class="fa fa-chevron-left"></span> Calendar
                 </a>
             </div>

--- a/views/event.html
+++ b/views/event.html
@@ -2,7 +2,7 @@
     <div class="container">
         <div class="row">
             <div class="col-xs-1">
-                <a class="btn btn-sm btn-default" ng-click="back()">
+                <a class="btn btn-sm btn-default" href="#/games-events?viewDate={{ game.date | date:'yyyy-MM-dd' }}&calendarView={{ calendarView }}">
                     <span class="fa fa-chevron-left"></span> Calendar
                 </a>
             </div>

--- a/views/game.html
+++ b/views/game.html
@@ -2,7 +2,7 @@
     <div class="container">
         <div class="row">
             <div class="col-xs-1">
-                <a class="btn btn-sm btn-default" href="#/games-events">
+                <a class="btn btn-sm btn-default" ng-click="back()">
                     <span class="fa fa-chevron-left"></span> Calendar
                 </a>
             </div>

--- a/views/game.html
+++ b/views/game.html
@@ -2,7 +2,7 @@
     <div class="container">
         <div class="row">
             <div class="col-xs-1">
-                <a class="btn btn-sm btn-default" ng-click="back()">
+                <a class="btn btn-sm btn-default" href="#/games-events/?viewDate={{ game.date | date:'yyyy-MM-dd' }}&calendarView={{ calendarView }}">
                     <span class="fa fa-chevron-left"></span> Calendar
                 </a>
             </div>

--- a/views/games-events.html
+++ b/views/games-events.html
@@ -7,21 +7,21 @@
             <div class="row">
                 <div class="col-md-6 text-center">
                     <div class="btn-group pull-left">
-                        <label class="btn btn-primary" ng-model="calendarView" uib-btn-radio="'year'" ng-click="cellIsOpen = false;updateView();">Year</label>
-                        <label class="btn btn-primary" ng-model="calendarView" uib-btn-radio="'month'" ng-click="cellIsOpen = false;updateView();">Month</label>
-                        <label class="btn btn-primary" ng-model="calendarView" uib-btn-radio="'week'" ng-click="cellIsOpen = false;updateView();">Week</label>
-                        <label class="btn btn-primary" ng-model="calendarView" uib-btn-radio="'day'" ng-click="cellIsOpen = false;updateView();">Day</label>
+                        <label class="btn btn-primary" ng-model="calendarView" uib-btn-radio="'year'" ng-click="cellIsOpen = false;">Year</label>
+                        <label class="btn btn-primary" ng-model="calendarView" uib-btn-radio="'month'" ng-click="cellIsOpen = false;">Month</label>
+                        <label class="btn btn-primary" ng-model="calendarView" uib-btn-radio="'week'" ng-click="cellIsOpen = false;">Week</label>
+                        <label class="btn btn-primary" ng-model="calendarView" uib-btn-radio="'day'" ng-click="cellIsOpen = false;">Day</label>
                     </div>
                 </div>
                 <div class="text-center" ng-class="{'col-md-5': admin, 'col-md-6': !admin}">
                     <div class="btn-group pull-right">
-                        <button class="btn btn-primary" mwl-date-modifier date="viewDate" decrement="calendarView" ng-click="cellIsOpen = false;updateDate();">
+                        <button class="btn btn-primary" mwl-date-modifier date="viewDate" decrement="calendarView" ng-click="cellIsOpen = false;">
                             Previous
                         </button>
-                        <button class="btn btn-primary" mwl-date-modifier date="viewDate" set-to-today ng-click="cellIsOpen = false;updateDate();">
+                        <button class="btn btn-primary" mwl-date-modifier date="viewDate" set-to-today ng-click="cellIsOpen = false;">
                             Today
                         </button>
-                        <button class="btn btn-primary" mwl-date-modifier date="viewDate" increment="calendarView" ng-click="cellIsOpen = false;updateDate();">
+                        <button class="btn btn-primary" mwl-date-modifier date="viewDate" increment="calendarView" ng-click="cellIsOpen = false;">
                             Next
                         </button>
                     </div>

--- a/views/games-events.html
+++ b/views/games-events.html
@@ -7,10 +7,10 @@
             <div class="row">
                 <div class="col-md-6 text-center">
                     <div class="btn-group pull-left">
-                        <label class="btn btn-primary" ng-model="calendarView" uib-btn-radio="'year'" ng-click="cellIsOpen = false">Year</label>
-                        <label class="btn btn-primary" ng-model="calendarView" uib-btn-radio="'month'" ng-click="cellIsOpen = false">Month</label>
-                        <label class="btn btn-primary" ng-model="calendarView" uib-btn-radio="'week'" ng-click="cellIsOpen = false">Week</label>
-                        <label class="btn btn-primary" ng-model="calendarView" uib-btn-radio="'day'" ng-click="cellIsOpen = false">Day</label>
+                        <label class="btn btn-primary" ng-model="calendarView" uib-btn-radio="'year'" ng-click="cellIsOpen = false;updateView();">Year</label>
+                        <label class="btn btn-primary" ng-model="calendarView" uib-btn-radio="'month'" ng-click="cellIsOpen = false;updateView();">Month</label>
+                        <label class="btn btn-primary" ng-model="calendarView" uib-btn-radio="'week'" ng-click="cellIsOpen = false;updateView();">Week</label>
+                        <label class="btn btn-primary" ng-model="calendarView" uib-btn-radio="'day'" ng-click="cellIsOpen = false;updateView();">Day</label>
                     </div>
                 </div>
                 <div class="text-center" ng-class="{'col-md-5': admin, 'col-md-6': !admin}">

--- a/views/games-events.html
+++ b/views/games-events.html
@@ -15,13 +15,13 @@
                 </div>
                 <div class="text-center" ng-class="{'col-md-5': admin, 'col-md-6': !admin}">
                     <div class="btn-group pull-right">
-                        <button class="btn btn-primary" mwl-date-modifier date="viewDate" decrement="calendarView" ng-click="cellIsOpen = false">
+                        <button class="btn btn-primary" mwl-date-modifier date="viewDate" decrement="calendarView" ng-click="cellIsOpen = false;updateDate();">
                             Previous
                         </button>
-                        <button class="btn btn-primary" mwl-date-modifier date="viewDate" set-to-today ng-click="cellIsOpen = false">
+                        <button class="btn btn-primary" mwl-date-modifier date="viewDate" set-to-today ng-click="cellIsOpen = false;updateDate();">
                             Today
                         </button>
-                        <button class="btn btn-primary" mwl-date-modifier date="viewDate" increment="calendarView" ng-click="cellIsOpen = false">
+                        <button class="btn btn-primary" mwl-date-modifier date="viewDate" increment="calendarView" ng-click="cellIsOpen = false;updateDate();">
                             Next
                         </button>
                     </div>


### PR DESCRIPTION
Closes #14.

This makes it so that when hitting any of the buttons above the calendar, it alters the URL, pushing it into the browser history so that when you click on an event/game, you can then hit back and be taken back to where you were on the calendar. The downside is that it does add every action so if you change the month 5 times, you'll have to hit the back button 5 times before you start hitting where you were before the calendar.