### PR TITLE
Fix ordering of crews around end of year rollover

### DIFF
--- a/views/night-crews.html
+++ b/views/night-crews.html
@@ -12,7 +12,7 @@
                 </tr>
                 </thead>
                 <tbody>
-                <tr ng-repeat="c in crews[t.attribute] | orderBy:'date'">
+                <tr ng-repeat="c in crews[t.attribute]">
                     <td>{{c.day}}</td>
                     <td>{{c.date | date:'shortDate'}}</td>
                     <td ng-repeat='p in positions'>


### PR DESCRIPTION
Closes #23

What was happening here was that this sort was doing a lexicographical sort using the date as a string, which meant that '01' < '12'. Since the data that's returned from the API is always in the right order, there's not much reason to need to order things here as well.