### PR TITLE
Difficulty Seeing "Other Agencies" Section Text

### DIFF
--- a/views/home.html
+++ b/views/home.html
@@ -136,15 +136,15 @@
 
 <section id="partners">
     <div class="container-fluid">
-        <div class="center">
-            <h2>Other Agencies</h2>
-
-            <p class="lead">RPI Ambulance works with other agencies both within the RPI community and throughout the
-                City of Troy and Rensselaer County.</p>
-        </div>
-    </div>
-    <div class="container-fluid">
         <div class="row partners">
+            <div class="container-fluid">
+                <div class="center">
+                    <h2>Other Agencies</h2>
+
+                    <p class="lead">RPI Ambulance works with other agencies both within the RPI community and throughout the
+                        City of Troy and Rensselaer County.</p>
+                </div>
+            </div>
             <div class="col-md-8 col-md-offset-2 center">
                 <ul>
                     <li><a href="http://www.rpi.edu/dept/public_safety/"><img class="partner" data-wow-duration="1000ms"


### PR DESCRIPTION
Fixed display issue where "Other Agencies" section text couldn't be seen because of the dark background.