### PR TITLE
Added support for Database Sessions

### DIFF
--- a/.delete_event.php
+++ b/.delete_event.php
@@ -1,7 +1,6 @@
 <?php
 if($_SERVER['REQUEST_METHOD'] === 'POST') {
   session_id($_POST['session_id']);
-  session_start();
 
   require_once ".db_config.php";
 
@@ -15,8 +14,10 @@ if($_SERVER['REQUEST_METHOD'] === 'POST') {
   if(!isset($_POST['event_id'])) {
     return;
   }
-
-  $username = $_SESSION['username'];
+  include ".get_user_metadata.php";
+  $user = getUser($_POST['session_id']);
+  $user = json_decode($user);
+  $username = $user->{'username'};
   $eventId = $_POST['event_id'];
 
   $statement = $connection->prepare("SELECT * FROM members WHERE username=:username");

--- a/.delete_event.php
+++ b/.delete_event.php
@@ -14,8 +14,8 @@ if($_SERVER['REQUEST_METHOD'] === 'POST') {
   if(!isset($_POST['event_id'])) {
     return;
   }
-  include ".get_user_metadata.php";
-  $user = getUser($_POST['session_id']);
+  include ".functions.php";
+  $user = getUser($_POST['session_id'], $connection);
   $user = json_decode($user);
   $username = $user->{'username'};
   $eventId = $_POST['event_id'];

--- a/.delete_game.php
+++ b/.delete_game.php
@@ -16,7 +16,10 @@ if($_SERVER['REQUEST_METHOD'] === 'POST') {
     return;
   }
 
-  $username = $_SESSION['username'];
+  include ".get_user_metadata.php";
+  $user = getUser($_POST['session_id']);
+  $user = json_decode($user);
+  $username = $user->{'username'};
   $gameId = $_POST['game_id'];
 
   $statement = $connection->prepare("SELECT * FROM members WHERE username=:username");

--- a/.delete_game.php
+++ b/.delete_game.php
@@ -16,8 +16,8 @@ if($_SERVER['REQUEST_METHOD'] === 'POST') {
     return;
   }
 
-  include ".get_user_metadata.php";
-  $user = getUser($_POST['session_id']);
+  include ".functions.php";
+  $user = getUser($_POST['session_id'], $connection);
   $user = json_decode($user);
   $username = $user->{'username'};
   $gameId = $_POST['game_id'];

--- a/.drop_event.php
+++ b/.drop_event.php
@@ -14,8 +14,8 @@ if($_SERVER['REQUEST_METHOD'] === 'POST') {
     return;
   }
 
-  include ".get_user_metadata.php";
-  $user = getUser($_POST['session_id']);
+  include ".functions.php";
+  $user = getUser($_POST['session_id'], $connection);
   $user = json_decode($user);
   $username = $user->{'username'};
   $eventId = $_POST['event_id'];

--- a/.drop_event.php
+++ b/.drop_event.php
@@ -1,7 +1,5 @@
 <?php
 if($_SERVER['REQUEST_METHOD'] === 'POST') {
-  session_id($_POST['session_id']);
-  session_start();
 
   require_once ".db_config.php";
 
@@ -16,7 +14,10 @@ if($_SERVER['REQUEST_METHOD'] === 'POST') {
     return;
   }
 
-  $username = $_SESSION['username'];
+  include ".get_user_metadata.php";
+  $user = getUser($_POST['session_id']);
+  $user = json_decode($user);
+  $username = $user->{'username'};
   $eventId = $_POST['event_id'];
 
   $statement = $connection->prepare("SELECT * FROM members WHERE username=:username");

--- a/.drop_event_other_member.php
+++ b/.drop_event_other_member.php
@@ -16,8 +16,8 @@ if($_SERVER['REQUEST_METHOD'] === 'POST') {
     return;
   }
 
-  include ".get_user_metadata.php";
-  $user = getUser($_POST['session_id']);
+  include ".functions.php";
+  $user = getUser($_POST['session_id'], $connection);
   $user = json_decode($user);
   $username = $user->{'username'};
   $eventId = $_POST['event_id'];

--- a/.drop_event_other_member.php
+++ b/.drop_event_other_member.php
@@ -16,7 +16,10 @@ if($_SERVER['REQUEST_METHOD'] === 'POST') {
     return;
   }
 
-  $username = $_SESSION['username'];
+  include ".get_user_metadata.php";
+  $user = getUser($_POST['session_id']);
+  $user = json_decode($user);
+  $username = $user->{'username'};
   $eventId = $_POST['event_id'];
   $memberToDelete = $_POST['member_id'];
 

--- a/.drop_game.php
+++ b/.drop_game.php
@@ -14,8 +14,8 @@ if($_SERVER['REQUEST_METHOD'] === 'POST') {
     return;
   }
 
-  include ".get_user_metadata.php";
-  $user = getUser($_POST['session_id']);
+  include ".functions.php";
+  $user = getUser($_POST['session_id'], $connection);
   $user = json_decode($user);
   $username = $user->{'username'};
   $gameId = $_POST['game_id'];

--- a/.drop_game.php
+++ b/.drop_game.php
@@ -1,7 +1,5 @@
 <?php
 if($_SERVER['REQUEST_METHOD'] === 'POST') {
-  session_id($_POST['session_id']);
-  session_start();
 
   require_once ".db_config.php";
 
@@ -16,7 +14,10 @@ if($_SERVER['REQUEST_METHOD'] === 'POST') {
     return;
   }
 
-  $username = $_SESSION['username'];
+  include ".get_user_metadata.php";
+  $user = getUser($_POST['session_id']);
+  $user = json_decode($user);
+  $username = $user->{'username'};
   $gameId = $_POST['game_id'];
 
   $statement = $connection->prepare("SELECT * FROM members WHERE username=:username");

--- a/.drop_game_other_member.php
+++ b/.drop_game_other_member.php
@@ -1,8 +1,6 @@
 <?php
 if($_SERVER['REQUEST_METHOD'] === 'POST') {
-  session_id($_POST['session_id']);
-  session_start();
-
+  
   require_once ".db_config.php";
 
   $connection = new PDO("mysql:host=$dhost;dbname=$dname", $duser, $dpassword);
@@ -16,7 +14,10 @@ if($_SERVER['REQUEST_METHOD'] === 'POST') {
     return;
   }
 
-  $username = $_SESSION['username'];
+  include ".get_user_metadata.php";
+  $user = getUser($_POST['session_id']);
+  $user = json_decode($user);
+  $username = $user->{'username'};
   $gameId = $_POST['game_id'];
   $memberToDelete = $_POST['member_id'];
 

--- a/.drop_game_other_member.php
+++ b/.drop_game_other_member.php
@@ -14,8 +14,8 @@ if($_SERVER['REQUEST_METHOD'] === 'POST') {
     return;
   }
 
-  include ".get_user_metadata.php";
-  $user = getUser($_POST['session_id']);
+  include ".functions.php";
+  $user = getUser($_POST['session_id'], $connection);
   $user = json_decode($user);
   $username = $user->{'username'};
   $gameId = $_POST['game_id'];

--- a/.edit_self.php
+++ b/.edit_self.php
@@ -21,11 +21,12 @@ if($_SERVER['REQUEST_METHOD'] === 'POST') {
   $home_address= $input['hadd'];
   $rpi_address = $input['add'];
   $sessionID = $input['session_id'];
-  session_id($sessionID);
-  session_start();
 
 try {
-  $username = $_SESSION['username'];
+  include ".get_user_metadata.php";
+  $user = getUser($sessionID);
+  $user = json_decode($user);
+  $username = $user->{'username'};
 
   $statement = $connection->prepare("SELECT * FROM members WHERE username=:username");
   $statement->bindParam(':username', $username);

--- a/.edit_self_pass.php
+++ b/.edit_self_pass.php
@@ -22,11 +22,12 @@ if($_SERVER['REQUEST_METHOD'] === 'POST') {
   $rpi_address = $input['add'];
   $pass = password_hash(hash('sha256', $input['pass']), PASSWORD_DEFAULT);
   $sessionID = $input['session_id'];
-  session_id($sessionID);
-  session_start();
 
 try {
-  $username = $_SESSION['username'];
+  include ".get_user_metadata.php";
+  $user = getUser($sessionID);
+  $user = json_decode($user);
+  $username = $user->{'username'};
 
   $statement = $connection->prepare("SELECT * FROM members WHERE username=:username");
   $statement->bindParam(':username', $username);

--- a/.edit_self_pass.php
+++ b/.edit_self_pass.php
@@ -24,8 +24,8 @@ if($_SERVER['REQUEST_METHOD'] === 'POST') {
   $sessionID = $input['session_id'];
 
 try {
-  include ".get_user_metadata.php";
-  $user = getUser($sessionID);
+  include ".functions.php";
+  $user = getUser($sessionID, $connection);
   $user = json_decode($user);
   $username = $user->{'username'};
 

--- a/.functions.php
+++ b/.functions.php
@@ -9,14 +9,13 @@ function checkIfAdmin() {
     return false;
   }
 
-  session_id($_GET['session_id']);
-  session_start();
-
-  if(!isset($_SESSION['username'])) {
+  include ".get_user_metadata.php";
+  $user = getUser($_GET['session_id']);
+  $user = json_decode($user);
+  $username = $user->{'username'};
+  if(!isset($username)) {
     return false;
   } else {
-    $username = $_SESSION['username'];
-
     $connection = new PDO("mysql:host={$dhost};dbname={$dname}", $duser, $dpassword);
     $connection->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 

--- a/.functions.php
+++ b/.functions.php
@@ -1,22 +1,17 @@
 <?php
-
-require_once '.db_config.php';
-
-function checkIfAdmin() {
-  global $dhost, $dname, $duser, $dpassword;
+function checkIfAdmin($connection) {
 
   if(!isset($_GET['session_id'])) {
     return false;
   }
 
-  include ".get_user_metadata.php";
-  $user = getUser($_GET['session_id']);
+  $user = getUser($_GET['session_id'], $connection);
   $user = json_decode($user);
   $username = $user->{'username'};
   if(!isset($username)) {
     return false;
   } else {
-    $connection = new PDO("mysql:host={$dhost};dbname={$dname}", $duser, $dpassword);
+    
     $connection->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 
     if(!isset($dname)) {
@@ -32,5 +27,53 @@ function checkIfAdmin() {
     $results=$statement->fetchAll(PDO::FETCH_ASSOC);
 
     return ($results[0]['admin'] == 1 || $results[0]['schedco'] == 1);
+  }
+}
+
+function getUser($sessionID, $connection){
+  if(isset($sessionID)){
+    $connection->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+  
+    if(!isset($dname)) {
+      $dname = 'ambulanc_web';
+    }
+  
+    $connection->exec("USE `$dname`");
+  
+    $statement = $connection->prepare('SELECT * FROM members LEFT JOIN sessions on sessions.userID = members.id WHERE sessions.sessionID = :sessionID');
+    $statement->bindParam(":sessionID", $sessionID);
+    $statement->execute();
+    $results=$statement->fetchAll(PDO::FETCH_ASSOC);
+    updateSession($sessionID, $connection);
+    return json_encode($results[0]);
+  }
+}
+
+function updateSession($sessionID, $connection){
+  if(!isset($dname)) {
+    $dname = 'ambulanc_web';
+  }
+  $connection->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+  $stmt = $connection->prepare('SELECT * FROM `sessions` WHERE sessionID = :sessionID');
+  $stmt->bindParam(":sessionID", $sessionID);
+  $stmt->execute();
+  $current_session = $stmt->fetch();
+  date_default_timezone_set('America/New_York');
+  $current_date = new DateTime();
+  $expiration = strtotime($current_session['expiration']);
+  if (time() < $expiration){
+    $current_date = $current_date->modify('+5 day');
+    $current_date = $current_date->format('Y-m-d H:i:s');
+    $stmt = $connection->prepare('UPDATE sessions SET expiration=:expiration WHERE sessionID=:sessionID');
+    $stmt->bindParam(":sessionID",$sessionID);
+    $stmt->bindParam(":expiration", $current_date);
+    $stmt->execute();
+    setcookie("RPIA-SESSION", $sessionID, strtotime("+5 day", time()), "/");
+  }else{
+    $stmt = $connection->prepare('DELETE FROM `sessions` WHERE sessionID=:sessionID');
+    $stmt->bindParam(":sessionID",$sessionID);
+    $stmt->execute();
+    // Expires in the past and therefore is deleted
+    setcookie("RPIA-SESSION", $sessionID, time() - 360000, "/");
   }
 }

--- a/.get_event_info.php
+++ b/.get_event_info.php
@@ -19,7 +19,10 @@ if($_SERVER['REQUEST_METHOD'] === 'POST') {
     return;
   }
 
-  $username = $_SESSION['username'];
+  include ".get_user_metadata.php";
+  $user = getUser($_POST['session_id']);
+  $user = json_decode($user);
+  $username = $user->{'username'};
   $eventId = $_POST['event_id'];
 
   $statement = $connection->prepare("SELECT * FROM members WHERE username=:username");

--- a/.get_event_info.php
+++ b/.get_event_info.php
@@ -19,8 +19,8 @@ if($_SERVER['REQUEST_METHOD'] === 'POST') {
     return;
   }
 
-  include ".get_user_metadata.php";
-  $user = getUser($_POST['session_id']);
+  include ".functions.php";
+  $user = getUser($_POST['session_id'], $connection);
   $user = json_decode($user);
   $username = $user->{'username'};
   $eventId = $_POST['event_id'];

--- a/.get_game_info.php
+++ b/.get_game_info.php
@@ -19,7 +19,10 @@ if($_SERVER['REQUEST_METHOD'] === 'POST') {
     return;
   }
 
-  $username = $_SESSION['username'];
+  include ".get_user_metadata.php";
+  $user = getUser($_POST['session_id']);
+  $user = json_decode($user);
+  $username = $user->{'username'};
   $gameId = $_POST['game_id'];
 
   $statement = $connection->prepare("SELECT * FROM members WHERE username=:username");

--- a/.get_game_info.php
+++ b/.get_game_info.php
@@ -19,8 +19,8 @@ if($_SERVER['REQUEST_METHOD'] === 'POST') {
     return;
   }
 
-  include ".get_user_metadata.php";
-  $user = getUser($_POST['session_id']);
+  include ".functions.php";
+  $user = getUser($_POST['session_id'],$connection);
   $user = json_decode($user);
   $username = $user->{'username'};
   $gameId = $_POST['game_id'];

--- a/.get_if_admin.php
+++ b/.get_if_admin.php
@@ -5,16 +5,15 @@
   if(!isset($_GET['session_id'])) {
     http_response_code(400);
   } else {
-    session_id($_GET['session_id']);
-    include ".get_user_metadata.php";
-    $user = getUser($_GET['session_id']);
+    $connection = new PDO("mysql:host=$dhost;dbname=$dname", $duser, $dpassword);
+    include ".functions.php";
+    $user = getUser($_GET['session_id'], $connection);
     $user = json_decode($user);
     $username = $user->username;
 
     if(!isset($username)) {
       echo json_encode(array("admin" => false, "scheduling_coordinator" => false));
     } else {
-      $connection = new PDO("mysql:host=$dhost;dbname=$dname", $duser, $dpassword);
       $connection->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 
       if(!isset($dname)) {

--- a/.get_if_admin.php
+++ b/.get_if_admin.php
@@ -6,10 +6,12 @@
     http_response_code(400);
   } else {
     session_id($_GET['session_id']);
-    session_start();
-    $username = $_SESSION['username'];
+    include ".get_user_metadata.php";
+    $user = getUser($_GET['session_id']);
+    $user = json_decode($user);
+    $username = $user->username;
 
-    if(!isset($_SESSION['username'])) {
+    if(!isset($username)) {
       echo json_encode(array("admin" => false, "scheduling_coordinator" => false));
     } else {
       $connection = new PDO("mysql:host=$dhost;dbname=$dname", $duser, $dpassword);

--- a/.get_session_info.php
+++ b/.get_session_info.php
@@ -1,17 +1,53 @@
 <?php
 if (isset($_GET['session_id'])){
-  if (isset($_SESSION['LAST_ACTIVITY']) && (time() - $_SESSION['LAST_ACTIVITY'] > 432000)) {
-    // last request was more than 5 days ago
-    session_unset();     // unset $_SESSION variable for the run-time
-    session_destroy();   // destroy session data in storage
-}
-$_SESSION['LAST_ACTIVITY'] = time(); // update last activity time stamp
-  session_id($_GET['session_id']);
-  session_start();
+  updateSession($sessionID);
+  $key = $_GET['key'];
+
+  if(!isset($key)){
+    exit();
+  }
+  
+  if($key == "username"){
+    include ".get_user_metadata.php";
+    $user = getUser($_GET['session_id']);
+    $user = json_decode($user);
+    $username = $user->{'username'};
+    echo json_encode(array($key => $username));
+  }else{
+    echo "Unsupported Key";
+  }
 }else{
-  session_start();
+  exit();
 }
-$key = $_GET['key'];
-echo json_encode(array($key => $_SESSION[$key]));
+function updateSession($sessionID){
+  require_once ".db_config.php";
+  if(!isset($dname)) {
+    $dname = 'ambulanc_web';
+  }
+  $connection = new PDO("mysql:host=$dhost;dbname=$dname", $duser, $dpassword);
+  $connection->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+  $stmt = $connection->prepare('SELECT * FROM `sessions` WHERE sessionID = :sessionID');
+  $stmt->bindParam(":sessionID", $_GET['session_id']);
+  $stmt->execute();
+  $current_session = $stmt->fetch();
+  date_default_timezone_set('America/New_York');
+  $current_date = new DateTime();
+  $expiration = strtotime($current_session['expiration']);
+  if (strtotime($current_date) < $expiration){
+    $current_date = $current_date->modify('+5 day');
+    $current_date = $current_date->format('Y-m-d H:i:s');
+    $stmt = $connection->prepare('UPDATE sessions SET expiration=:expiration WHERE sessionID=:sessionID');
+    $stmt->bindParam(":sessionID",$_GET['session_id']);
+    $stmt->bindParam(":expiration", $current_date);
+    $stmt->execute();
+    setcookie("RPIA-SESSION", $_GET['session_id'], strtotime("+5 day", time()), "/");
+  }else{
+    $stmt = $connection->prepare('DELETE FROM `sessions` WHERE sessionID=:sessionID');
+    $stmt->bindParam(":sessionID",$_GET['session_id']);
+    $stmt->execute();
+    // Expires in the past and therefore is deleted
+    setcookie("RPIA-SESSION", $_GET['session_id'], time() - 360000, "/");
+  }
+}
 
 ?>

--- a/.get_session_info.php
+++ b/.get_session_info.php
@@ -1,6 +1,9 @@
 <?php
+require_once ".db_config.php";
+include ".functions.php";
 if (isset($_GET['session_id'])){
-  updateSession($sessionID);
+  $connection = new PDO("mysql:host=$dhost;dbname=$dname", $duser, $dpassword);
+  updateSession($sessionID, $connection);
   $key = $_GET['key'];
 
   if(!isset($key)){
@@ -8,8 +11,7 @@ if (isset($_GET['session_id'])){
   }
   
   if($key == "username"){
-    include ".get_user_metadata.php";
-    $user = getUser($_GET['session_id']);
+    $user = getUser($_GET['session_id'], $connection);
     $user = json_decode($user);
     $username = $user->{'username'};
     echo json_encode(array($key => $username));
@@ -18,36 +20,6 @@ if (isset($_GET['session_id'])){
   }
 }else{
   exit();
-}
-function updateSession($sessionID){
-  require_once ".db_config.php";
-  if(!isset($dname)) {
-    $dname = 'ambulanc_web';
-  }
-  $connection = new PDO("mysql:host=$dhost;dbname=$dname", $duser, $dpassword);
-  $connection->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
-  $stmt = $connection->prepare('SELECT * FROM `sessions` WHERE sessionID = :sessionID');
-  $stmt->bindParam(":sessionID", $_GET['session_id']);
-  $stmt->execute();
-  $current_session = $stmt->fetch();
-  date_default_timezone_set('America/New_York');
-  $current_date = new DateTime();
-  $expiration = strtotime($current_session['expiration']);
-  if (strtotime($current_date) < $expiration){
-    $current_date = $current_date->modify('+5 day');
-    $current_date = $current_date->format('Y-m-d H:i:s');
-    $stmt = $connection->prepare('UPDATE sessions SET expiration=:expiration WHERE sessionID=:sessionID');
-    $stmt->bindParam(":sessionID",$_GET['session_id']);
-    $stmt->bindParam(":expiration", $current_date);
-    $stmt->execute();
-    setcookie("RPIA-SESSION", $_GET['session_id'], strtotime("+5 day", time()), "/");
-  }else{
-    $stmt = $connection->prepare('DELETE FROM `sessions` WHERE sessionID=:sessionID');
-    $stmt->bindParam(":sessionID",$_GET['session_id']);
-    $stmt->execute();
-    // Expires in the past and therefore is deleted
-    setcookie("RPIA-SESSION", $_GET['session_id'], time() - 360000, "/");
-  }
 }
 
 ?>

--- a/.get_user_metadata.php
+++ b/.get_user_metadata.php
@@ -1,30 +1,12 @@
 <?php
 
 require_once '.db_config.php';
+include ".functions.php";
 
 if(isset($_GET['session_id'])){
-  echo getUser($_GET['session_id']);
+  $connection = new PDO("mysql:host=$dhost;dbname=$dname", $duser, $dpassword);
+  echo getUser($_GET['session_id'], $connection);
 }else{
   exit();
-}
-function getUser($sessionID){
-  if(isset($sessionID)){
-    $connection = new PDO("mysql:host=$dhost;dbname=$dname", $duser, $dpassword);
-    $connection->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
-  
-    if(!isset($dname)) {
-      $dname = 'ambulanc_web';
-    }
-  
-    $connection->exec("USE `$dname`");
-  
-    $statement = $connection->prepare('SELECT * FROM members LEFT JOIN sessions on sessions.userID = members.id WHERE sessions.sessionID = :sessionID');
-    $statement->bindParam(":sessionID", $sessionID);
-    $statement->execute();
-    include ".get_session_info.php";
-    updateSession($sessionID);
-    $results=$statement->fetchAll(PDO::FETCH_ASSOC);
-    return json_encode($results[0]);
-  }
 }
 ?>

--- a/.get_user_metadata.php
+++ b/.get_user_metadata.php
@@ -2,29 +2,29 @@
 
 require_once '.db_config.php';
 
-session_id($_GET['session_id']);
-session_start();
-
-if(!isset($_SESSION['username'])) {
-  echo 0;
-} else {
-  $username = $_SESSION['username'];
-
-  $connection = new PDO("mysql:host=$dhost;dbname=$dname", $duser, $dpassword);
-  $connection->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
-
-  if(!isset($dname)) {
-    $dname = 'ambulanc_web';
+if(isset($_GET['session_id'])){
+  echo getUser($_GET['session_id']);
+}else{
+  exit();
+}
+function getUser($sessionID){
+  if(isset($sessionID)){
+    $connection = new PDO("mysql:host=$dhost;dbname=$dname", $duser, $dpassword);
+    $connection->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+  
+    if(!isset($dname)) {
+      $dname = 'ambulanc_web';
+    }
+  
+    $connection->exec("USE `$dname`");
+  
+    $statement = $connection->prepare('SELECT * FROM members LEFT JOIN sessions on sessions.userID = members.id WHERE sessions.sessionID = :sessionID');
+    $statement->bindParam(":sessionID", $sessionID);
+    $statement->execute();
+    include ".get_session_info.php";
+    updateSession($sessionID);
+    $results=$statement->fetchAll(PDO::FETCH_ASSOC);
+    return json_encode($results[0]);
   }
-
-  $connection->exec("USE `$dname`");
-
-  $statement = $connection->prepare('SELECT * FROM members WHERE username = :username');
-  $statement->bindParam(":username", $username);
-  $statement->execute();
-
-  $results=$statement->fetchAll(PDO::FETCH_ASSOC);
-
-  echo json_encode($results[0]);
 }
 ?>

--- a/.logout.php
+++ b/.logout.php
@@ -3,17 +3,12 @@
 if(!isset($_GET['session_id'])) {
     http_response_code(400);
 } else {
-    session_id($_GET['session_id']);
-    session_start();
-
-    if(session_destroy()) {
-        unset($_SESSION['username']);
-        unset($_SESSION['first_name']);
-        unset($_SESSION['last_name']);
-        echo 'true';
-    } else {
-        http_response_code(500);
-    }
+    $stmt = $connection->prepare('DELETE FROM sessions WHERE sessionID=:sessionID');
+    $stmt->bindParam(":sessionID",$_GET['session_id']);
+    $stmt->execute();
+    // Expires in the past and therefore is deleted (This is redundent as it is removed in the javascript)
+    //setcookie("RPIA-SESSION", $_GET['session_id'], time() - 360000, "/");
+    echo 'true';
 }
 
 ?>

--- a/.signup_event.php
+++ b/.signup_event.php
@@ -14,8 +14,8 @@ if($_SERVER['REQUEST_METHOD'] === 'POST') {
     return;
   }
 
-  include ".get_user_metadata.php";
-  $user = getUser($_POST['session_id']);
+  include ".functions.php";
+  $user = getUser($_POST['session_id'], $connection);
   $user = json_decode($user);
   $username = $user->{'username'};
   $eventId = $_POST['event_id'];

--- a/.signup_event.php
+++ b/.signup_event.php
@@ -1,7 +1,5 @@
 <?php
 if($_SERVER['REQUEST_METHOD'] === 'POST') {
-  session_id($_POST['session_id']);
-  session_start();
 
   require_once ".db_config.php";
 
@@ -16,7 +14,10 @@ if($_SERVER['REQUEST_METHOD'] === 'POST') {
     return;
   }
 
-  $username = $_SESSION['username'];
+  include ".get_user_metadata.php";
+  $user = getUser($_POST['session_id']);
+  $user = json_decode($user);
+  $username = $user->{'username'};
   $eventId = $_POST['event_id'];
 
   $statement = $connection->prepare("SELECT * FROM members WHERE username=:username");

--- a/.signup_game.php
+++ b/.signup_game.php
@@ -1,8 +1,5 @@
 <?php
 if($_SERVER['REQUEST_METHOD'] === 'POST') {
-  session_id($_POST['session_id']);
-  session_start();
-
   require_once ".db_config.php";
 
   $connection = new PDO("mysql:host=$dhost;dbname=$dname", $duser, $dpassword);
@@ -16,7 +13,10 @@ if($_SERVER['REQUEST_METHOD'] === 'POST') {
     return;
   }
 
-  $username = $_SESSION['username'];
+  include ".get_user_metadata.php";
+  $user = getUser($_POST['session_id']);
+  $user = json_decode($user);
+  $username = $user->{'username'};
   $gameId = $_POST['game_id'];
   $position = $_POST['position'];
 

--- a/.signup_game.php
+++ b/.signup_game.php
@@ -13,8 +13,8 @@ if($_SERVER['REQUEST_METHOD'] === 'POST') {
     return;
   }
 
-  include ".get_user_metadata.php";
-  $user = getUser($_POST['session_id']);
+  include ".functions.php";
+  $user = getUser($_POST['session_id'], $connection);
   $user = json_decode($user);
   $username = $user->{'username'};
   $gameId = $_POST['game_id'];

--- a/js/controllers/LoginCtrl.js
+++ b/js/controllers/LoginCtrl.js
@@ -22,6 +22,7 @@ angular.module('LoginCtrl', []).controller('LoginCtrl', ['$scope', '$http', '$lo
         AuthService.login($scope.formData).then(function (response) {
             $location.path('/night-crews');
         }, function (error) {
+            console.log(error);
             if (error.data.fail_type == "locked") {
               sweetAlert("Account Disabled", error.data.errors.locked, "error");
             }

--- a/js/controllers/NightCrewsCtrl.js
+++ b/js/controllers/NightCrewsCtrl.js
@@ -84,6 +84,7 @@ angular.module('NightCrewsCtrl', []).controller('NightCrewsCtrl', ['$scope', '$h
             data: "session_id=" + AuthService.getSessionId() + "&view_date=" + DateService.formatViewDate($scope.viewDateWeek),
             headers: {'Content-Type': 'application/x-www-form-urlencoded'}
         }).then(function (response) {
+            console.log(response);
             if (!response.data.success) {
                 console.log("it failed!");
                 console.log(response.data);

--- a/js/services/AuthService.js
+++ b/js/services/AuthService.js
@@ -1,5 +1,5 @@
 angular.module('AuthService', []).service('AuthService', ['$http', '$q', '$cookies', '$location', function ($http, $q, $cookies, $location) {
-    var SESSION_ID_COOKIE = '__RPIA_SESSION_ID';
+    var SESSION_ID_COOKIE = 'RPIA-SESSION';
 
     this.login = function (formData) {
         var deferred = $q.defer();
@@ -15,8 +15,7 @@ angular.module('AuthService', []).service('AuthService', ['$http', '$q', '$cooki
             } else {
                 var date = new Date();
                 date.setDate(date.getDate() + 5); //create date object 5 days from NOW
-                $cookies.put(SESSION_ID_COOKIE, response.data.session_id, {expires: date}); //set cookie expiration to that date
-                $cookies.put('PHPSESSID', response.data.session_id, {expires: date}); //Extends PHP Session cookie to match expiration of RPI Ambulance Cookie
+                $cookies.put(SESSION_ID_COOKIE, response.data.session_id, {expires: date}); //set cookie expiration to that dateie
                 deferred.resolve(response);
             }
         });
@@ -94,7 +93,6 @@ angular.module('AuthService', []).service('AuthService', ['$http', '$q', '$cooki
                 var date = new Date();
                 date.setDate(date.getDate() + 5); //create date object 5 days from NOW
                 $cookies.put(SESSION_ID_COOKIE, sessionId, {expires: date}); //reset cookie expiration to that date
-                $cookies.put('PHPSESSID', sessionId, {expires: date}); //reset PHP Session cookie to match expiration of RPI Ambulance Cookie
                 deferred.resolve(true);
             } else {
                 //Commented out because it doesn't work currently and is just annoying

--- a/member_table.php
+++ b/member_table.php
@@ -5,8 +5,8 @@
 
 require_once ".db_config.php";
 
-include ".get_user_metadata.php";
-$user = getUser($_GET['session_id']);
+include ".functions.php";
+$user = getUser($_GET['session_id'], $connection);
 $user = json_decode($user);
 $username = $user->{'username'};
 if(!isset($username)) {

--- a/member_table.php
+++ b/member_table.php
@@ -5,14 +5,14 @@
 
 require_once ".db_config.php";
 
-session_id($_GET['session_id']);
-session_start();
-if(!isset($_SESSION['username'])) {
+include ".get_user_metadata.php";
+$user = getUser($_GET['session_id']);
+$user = json_decode($user);
+$username = $user->{'username'};
+if(!isset($username)) {
   echo 0;
 } else {
-  $username = $_SESSION['username'];
 	
-
 $connection = new PDO("mysql:host=$dhost;dbname=$dname", $duser, $dpassword);
 $connection->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 


### PR DESCRIPTION
Removed PHP Sessions due to unexpected behavior when being run on a cPanel server which led to the sessions being collected prematurely. Moving it into our database allows for us to have granular control of when the cookie is an isn't given. Right now it is 5 days of inactivity leads to log out.

TODO:
Add a config file to specify how long it should be until you log out because right now 5 days is hard coded.
Remove all the session_start(); requests that are floating around. Not a huge deal right now as we don't use any $_SESSION variables anymore in the code.