### PR TITLE
Fix accessibility stuff on homepage

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -2514,7 +2514,7 @@ shortcodes page css
 }
 
 #bottom ul li a {
-    color: #808080;
+    color: #535353;
 }
 
 #bottom ul li a:hover {

--- a/index.html
+++ b/index.html
@@ -107,17 +107,17 @@
                     </div>
                   </li>
                   <li>
-                    <a href="https://www.facebook.com/rpiamb"
+                    <a href="https://www.facebook.com/rpiamb" aria-label="Visit our Facebook"
                       ><i class="fa fa-facebook"></i
                     ></a>
                   </li>
                   <li>
-                    <a href="https://www.instagram.com/rpiambulance"
+                    <a href="https://www.instagram.com/rpiambulance" aria-label="Visit our Instagram"
                       ><i class="fa fa-instagram"></i
                     ></a>
                   </li>
                   <li>
-                    <a href="https://reddit.com/u/RPIAMBULANCE"
+                    <a href="https://reddit.com/u/RPIAMBULANCE" aria-label="Visit our Reddit Profile"
                       ><i class="fa fa-reddit-alien"></i
                     ></a>
                   </li>

--- a/views/home.html
+++ b/views/home.html
@@ -148,14 +148,19 @@
             <div class="col-md-8 col-md-offset-2 center">
                 <ul>
                     <li><a href="http://www.rpi.edu/dept/public_safety/"><img class="partner" data-wow-duration="1000ms"
+                                         alt="RPI Public Safety Logo" title="RPI Public Safey"
                                          data-wow-delay="300ms" src="img/partners/new/pubsafe.svg"></a></li>
                     <li><a href="http://studenthealth.rpi.edu/"><img class="partner" data-wow-duration="1000ms"
+                                         alt="RPI Student Health Logo" title="RPI Student Health"
                                          data-wow-delay="600ms" src="img/partners/new/shc.svg"></a></li>
                     <li><a href="http://www.remo-ems.com/"><img class="partner" data-wow-duration="1000ms"
+                                         alt="REMO Logo" title="REMO"
                                          data-wow-delay="900ms" src="img/partners/new/remo.svg"></a></li>
                     <li><a href="http://www.rensco.com/departments/public-safety/"><img class="partner" data-wow-duration="1000ms"
+                                         alt="RENSCO Logo" title="RENSCO"
                                          data-wow-delay="1200ms" src="img/partners/RENSCO.svg"></a></li>
                     <li><a href="http://www.troyny.gov/departments/fire-department/"><img class="partner" data-wow-duration="1000ms"
+                                         alt="Troy Fire Department Logo" title="Troy Fire Department"
                                          data-wow-delay="1500ms" src="img/partners/new/tfd.svg"></a></li>
                 </ul>
             </div>


### PR DESCRIPTION
This fixes a handful of errors and contrast things as pointed out by https://wave.webaim.org/ for accessibility:
* Update the FG/IG/Reddit icons to have labels (instead of being blank links)
* Update footer "partner" images to have alt and title texts
* Update color of links in footer to have much better contrast (up from 3.62:1 to 7.06:1)