### PR TITLE
Fix epoch stuff

### DIFF
--- a/.get_event_info.php
+++ b/.get_event_info.php
@@ -35,7 +35,7 @@ if($_SERVER['REQUEST_METHOD'] === 'POST') {
 
   $results = array();
 
-  $sql = "SELECT *, UNIX_TIMESTAMP(start) AS start_epoch, UNIX_TIMESTAMP(end) AS end_epoch FROM events WHERE id = :eventId";
+  $sql = "SELECT *, UNIX_TIMESTAMP(CONCAT(CURRENT_DATE(), ' ', CONVERT(start, CHARACTER))) AS start_epoch, UNIX_TIMESTAMP(CONCAT(CURRENT_DATE(), ' ', CONVERT(end, CHARACTER))) AS end_epoch FROM events WHERE id = :eventId";
   $statement=$connection->prepare($sql);
   $statement->bindValue(':eventId', $eventId);
   $statement->execute();

--- a/.get_game_info.php
+++ b/.get_game_info.php
@@ -35,7 +35,7 @@ if($_SERVER['REQUEST_METHOD'] === 'POST') {
 
   $results = array();
 
-  $sql = "SELECT *, UNIX_TIMESTAMP(start) AS start_epoch, UNIX_TIMESTAMP(end) AS end_epoch FROM games WHERE id = :gameId";
+  $sql = "SELECT *, UNIX_TIMESTAMP(CONCAT(CURRENT_DATE(), ' ', CONVERT(start, CHARACTER))) AS start_epoch, UNIX_TIMESTAMP(CONCAT(CURRENT_DATE(), ' ', CONVERT(end, CHARACTER))) AS end_epoch FROM games WHERE id = :gameId";
   $statement=$connection->prepare($sql);
   $statement->bindValue(':gameId', $gameId);
   $statement->execute();


### PR DESCRIPTION
Fixes the `startObj`s and `endObj`s being invalid due to [something weird](https://jira.mariadb.org/browse/MDEV-20695) in MariaDB.

Tested on the SQL server and a valid epoch value is returned.