### PR TITLE
add zip and unzip to website Dockerfile for composer package installation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,8 @@ RUN apt-get update \
         curl \
         git \
         sudo \
+        unzip \
+        zip \
     && curl -sL https://deb.nodesource.com/setup_10.x | bash - \
     && apt-get install -y nodejs \
     && npm install -g bower \


### PR DESCRIPTION
When installing packages where `zip` and `unzip` are missing, Docker outputs this as part of the build log:
```
Loading composer repositories with package information
Installing dependencies from lock file
Package operations: 13 installs, 0 updates, 0 removals
    Failed to download phpseclib/phpseclib from dist: The zip extension and unzip command are both missing, skipping.
Your command-line PHP is using multiple ini files. Run `php --ini` to show them.
    Now trying to download from source
  - Installing phpseclib/phpseclib (2.0.21): Cloning 9f1287e68b from cache
    Failed to download psr/log from dist: The zip extension and unzip command are both missing, skipping.
...
```

where this is repeated for many packages that attempt to be installed.