### PR TITLE
Add redirect to use on insta

### DIFF
--- a/slack-blog/index.html
+++ b/slack-blog/index.html
@@ -1,0 +1,1 @@
+< ?php header("Location: https://slackhq.com/rpi-ambulance-saves-lives-faster-with-slack"); ?>


### PR DESCRIPTION
This will allow `https://rpiambulance.com/slack-blog` to be used as a redirect. Instagram doesn't allow for hyperlinks in their captions, so this will allow our near-future post's viewers the ability to type in a quick URL to get to the blog.