### PR TITLE
Use nginx container to run site instead of apache

### DIFF
--- a/.docker/nginx/site.conf
+++ b/.docker/nginx/site.conf
@@ -1,0 +1,25 @@
+server {
+    listen 80 default_server;
+    listen [::]:80 default_server;
+
+    index index.php index.html;
+    server_name _;
+    error_log  /var/log/nginx/error.log;
+    access_log /var/log/nginx/access.log;
+
+    root /var/www/html/;
+
+    location / {
+        try_files $uri $uri/ =404;
+    }
+
+    location ~ \.php$ {
+        try_files $uri =404;
+        fastcgi_split_path_info ^(.+\.php)(/.+)$;
+        fastcgi_pass php:9000;
+        fastcgi_index index.php;
+        include fastcgi_params;
+        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+        fastcgi_param PATH_INFO $fastcgi_path_info;
+    }
+}

--- a/Dockerfile-php
+++ b/Dockerfile-php
@@ -1,4 +1,4 @@
-FROM php:7.2-apache
+FROM php:7.2-fpm
 
 ARG build_env=production
 
@@ -14,9 +14,6 @@ RUN apt-get update \
         sudo \
         unzip \
         zip \
-    && curl -sL https://deb.nodesource.com/setup_10.x | bash - \
-    && apt-get install -y nodejs \
-    && npm install -g bower \
     && docker-php-ext-install pdo pdo_mysql \
     && php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" \
     && php -r "if (hash_file('sha384', 'composer-setup.php') === 'a5c698ffe4b8e849a443b120cd5ba38043260d5c4023dbf93e1558871f1f07f58274fc6f4c93bcfd858c6bd0775cd8d1') { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); } echo PHP_EOL;" \
@@ -29,5 +26,4 @@ RUN apt-get update \
     && mkdir -p /var/www/.config \
     && chown www-data:www-data /var/www/ \
     && chown www-data:www-data /var/www/.config \
-    && sudo -u www-data /bin/bash -c "bower install --production" \
     && sudo -u www-data /bin/bash -c "composer install --no-dev --optimize-autoloader"

--- a/Dockerfile-web
+++ b/Dockerfile-web
@@ -1,0 +1,19 @@
+FROM nginx:latest
+
+COPY . /var/www/html
+
+WORKDIR /var/www/html
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        curl \
+        git \
+        sudo \
+    && curl -sL https://deb.nodesource.com/setup_10.x | bash - \
+    && apt-get install -y nodejs \
+    && npm install -g bower \
+    && rm -rf /var/lib/apt/lists/* \
+    && mkdir -p /var/www/.config \
+    && chown -R www-data:www-data /var/www/ \
+    && sudo -u www-data /bin/bash -c "bower install --production"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,10 +3,20 @@ services:
   web:
     build:
       context: .
-      args:
-        build_env: production
+      dockerfile: Dockerfile-web
+    volumes:
+      - .docker/nginx/site.conf:/etc/nginx/conf.d/default.conf
     ports:
       - "8080:80"
+    depends_on:
+      - php
+
+  php:
+    build:
+      context: .
+      dockerfile: Dockerfile-php
+      args:
+        build_env: production
     volumes:
       - .admin_config.php:/var/www/html/.admin_config.php
       - .db_config.php:/var/www/html/.db_config.php


### PR DESCRIPTION
This adds a new container that contains nginx, bower, and all of the static non-php assets, and then strips the php one of apache.