### PR TITLE
do not show welcome line in header until angular loads

### DIFF
--- a/index.html
+++ b/index.html
@@ -103,6 +103,7 @@
                       class="top-number"
                       ng-if="user"
                       style="padding-right: 5px"
+                      ng-cloak
                     >
                       Welcome, {{user}}!
                     </div>


### PR DESCRIPTION
This fixes the flicker of `Welcome, {{user}}!` in the header while angular loads. It uses the standard [`ngCloak`](https://docs.angularjs.org/api/ng/directive/ngCloak) directive to accomplish it.

Now, for a user that is not logged in, nothing will be shown, and for a user that is logged in, it will show the welcome line.