### PR TITLE
Add duty supervisor to database and website (and support for /whoson)

### DIFF
--- a/.crews.php
+++ b/.crews.php
@@ -321,8 +321,13 @@ function main () {
 
                 // Loops through all the spots and checks if there is a CC on in any of them.
                 foreach($positions as $pos) {
+                    // Duty sup is not actively on night crew
+                    if($pos == 'dutysup') {
+                        continue;
+                    }
+
                     $statement = $connection->prepare("SELECT * FROM members WHERE id = :memberid LIMIT 1");
-                    $statement->bindValue(':memberid', $y['cc']);
+                    $statement->bindValue(':memberid', $y[$pos]);
                     $statement->execute();
                     $posMember = $statement->fetchAll(PDO::FETCH_ASSOC);
 
@@ -331,12 +336,6 @@ function main () {
                     }
 
                     $posMember = $posMember[0];
-
-
-                    // Duty sup is not actively on night crew
-                    if($posMember['dutysup']) {
-                        continue;
-                    }
 
                     if($posMember['cctrainer']) {
                         $ccton[$x] = 1;

--- a/.crews.php
+++ b/.crews.php
@@ -332,6 +332,12 @@ function main () {
 
                     $posMember = $posMember[0];
 
+
+                    // Duty sup is not actively on night crew
+                    if($posMember['dutysup']) {
+                        continue;
+                    }
+
                     if($posMember['cctrainer']) {
                         $ccton[$x] = 1;
                     }

--- a/.crews.php
+++ b/.crews.php
@@ -181,13 +181,14 @@ function processTurnover ($connection) {
 
                 $date = date('Y-m-d', mktime(0, 0, 0, date('m'), date('d') + $i, date('Y')));
 
-                $statement = $connection->prepare("INSERT INTO crews (id, date, cc, driver, attendant, observer) VALUES (:logid, :date, :cc, :driver, :attendant, :observer)");
+                $statement = $connection->prepare("INSERT INTO crews (id, date, cc, driver, attendant, observer, dutysup) VALUES (:logid, :date, :cc, :driver, :attendant, :observer, :dutysup)");
                 $statement->bindValue(":logid", $logid);
                 $statement->bindValue(":date", $date);
                 $statement->bindValue(":cc", $default['cc']);
                 $statement->bindValue(":driver", $default['driver']);
                 $statement->bindValue(":attendant", $default['attendant']);
                 $statement->bindValue(":observer", $default['observer']);
+                $statement->bindValue(":dutysup", $default['dutysup']);
                 $statement->execute();
             }
         }
@@ -243,7 +244,7 @@ function main () {
 
     $response = array(
         "headings" => array(
-            'Night', 'Date', 'Crew Chief', 'Driver', 'Rider', 'Rider'
+            'Night', 'Date', 'Crew Chief', 'Driver', 'Rider', 'Rider', 'Duty Supervisor'
         ),
         "crews" => array(
             "currentWeek" => array(),
@@ -315,7 +316,7 @@ function main () {
                 }
 
                 $positions = [
-                    'cc', 'driver', 'attendant', 'observer'
+                    'cc', 'driver', 'attendant', 'observer', 'dutysup'
                 ];
 
                 // Loops through all the spots and checks if there is a CC on in any of them.
@@ -324,7 +325,7 @@ function main () {
                     $statement->bindValue(':memberid', $y['cc']);
                     $statement->execute();
                     $posMember = $statement->fetchAll(PDO::FETCH_ASSOC);
-                    
+
                     if (sizeof($posMember) == 0) {
                         continue;
                     }
@@ -368,7 +369,7 @@ function main () {
             );
 
             $positons = [
-                'cc', 'driver', 'attendant', 'observer'
+		    'cc', 'driver', 'attendant', 'observer', 'dutysup'
             ];
 
             foreach($positons as $pos) {

--- a/.defaults.php
+++ b/.defaults.php
@@ -23,12 +23,13 @@ if($_SERVER['REQUEST_METHOD'] === 'POST') {
 
     try {
       foreach($data as $elem) {
-        $sql = "UPDATE default_crews SET cc=:cc, driver=:driver, attendant=:attendant, observer=:observer WHERE day=:day";
+        $sql = "UPDATE default_crews SET cc=:cc, driver=:driver, attendant=:attendant, observer=:observer, dutysup=:dutysup WHERE day=:day";
         $statement = $connection->prepare($sql);
         $statement->bindParam(':cc', $elem['cc']);
         $statement->bindParam(':driver', $elem['driver']);
         $statement->bindParam(':attendant', $elem['attendant']);
         $statement->bindParam(':observer', $elem['observer']);
+        $statement->bindParam(':dutysup', $elem['dutysup']);
         $statement->bindParam(':day', $elem['day']);
         $result = $statement->execute();
       }

--- a/.docker/mysql/default.sql
+++ b/.docker/mysql/default.sql
@@ -2,13 +2,13 @@
 
 USE `ambulanc_web`;
 
-INSERT INTO `default_crews` (`day`, `cc`, `driver`, `attendant`, `observer`) VALUES ('0', '0', '0', '0', '0');
-INSERT INTO `default_crews` (`day`, `cc`, `driver`, `attendant`, `observer`) VALUES ('1', '0', '0', '0', '0');
-INSERT INTO `default_crews` (`day`, `cc`, `driver`, `attendant`, `observer`) VALUES ('2', '0', '0', '0', '0');
-INSERT INTO `default_crews` (`day`, `cc`, `driver`, `attendant`, `observer`) VALUES ('3', '0', '0', '0', '0');
-INSERT INTO `default_crews` (`day`, `cc`, `driver`, `attendant`, `observer`) VALUES ('4', '0', '0', '0', '0');
-INSERT INTO `default_crews` (`day`, `cc`, `driver`, `attendant`, `observer`) VALUES ('5', '0', '0', '0', '0');
-INSERT INTO `default_crews` (`day`, `cc`, `driver`, `attendant`, `observer`) VALUES ('6', '0', '0', '0', '0');
+INSERT INTO `default_crews` (`day`, `cc`, `driver`, `attendant`, `observer`, `dutysup`) VALUES ('0', '0', '0', '0', '0', '0');
+INSERT INTO `default_crews` (`day`, `cc`, `driver`, `attendant`, `observer`, `dutysup`) VALUES ('1', '0', '0', '0', '0', '0');
+INSERT INTO `default_crews` (`day`, `cc`, `driver`, `attendant`, `observer`, `dutysup`) VALUES ('2', '0', '0', '0', '0', '0');
+INSERT INTO `default_crews` (`day`, `cc`, `driver`, `attendant`, `observer`, `dutysup`) VALUES ('3', '0', '0', '0', '0', '0');
+INSERT INTO `default_crews` (`day`, `cc`, `driver`, `attendant`, `observer`, `dutysup`) VALUES ('4', '0', '0', '0', '0', '0');
+INSERT INTO `default_crews` (`day`, `cc`, `driver`, `attendant`, `observer`, `dutysup`) VALUES ('5', '0', '0', '0', '0', '0');
+INSERT INTO `default_crews` (`day`, `cc`, `driver`, `attendant`, `observer`, `dutysup`) VALUES ('6', '0', '0', '0', '0', '0');
 
 INSERT INTO `members`(`id`, `username`, `password`, `first_name`, `last_name`, `dob`, `email`, `rpi_address`, `home_address`,
   `cell_phone`, `home_phone`, `rcs_id`, `rin`, `radionum`, `radio`, `radiomodel`, `radioserial`, `radiocharger`, `radiotacmic`,

--- a/.docker/mysql/schema.sql
+++ b/.docker/mysql/schema.sql
@@ -18,7 +18,7 @@ CREATE TABLE `crews` (
   `cc` int(10) NOT NULL DEFAULT '0',
   `driver` int(10) NOT NULL DEFAULT '0',
   `attendant` int(10) NOT NULL DEFAULT '0',
-  `observer` int(10) NOT NULL DEFAULT '0'
+  `observer` int(10) NOT NULL DEFAULT '0',
   `dutysup` int(10) NOT NULL DEFAULT '0'
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
@@ -33,7 +33,7 @@ CREATE TABLE `default_crews` (
   `cc` int(10) NOT NULL,
   `driver` int(10) NOT NULL,
   `attendant` int(10) NOT NULL,
-  `observer` int(10) NOT NULL
+  `observer` int(10) NOT NULL,
   `dutysup` int(10) NOT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 

--- a/.docker/mysql/schema.sql
+++ b/.docker/mysql/schema.sql
@@ -19,6 +19,7 @@ CREATE TABLE `crews` (
   `driver` int(10) NOT NULL DEFAULT '0',
   `attendant` int(10) NOT NULL DEFAULT '0',
   `observer` int(10) NOT NULL DEFAULT '0'
+  `dutysup` int(10) NOT NULL DEFAULT '0'
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 -- --------------------------------------------------------
@@ -33,6 +34,7 @@ CREATE TABLE `default_crews` (
   `driver` int(10) NOT NULL,
   `attendant` int(10) NOT NULL,
   `observer` int(10) NOT NULL
+  `dutysup` int(10) NOT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 -- --------------------------------------------------------

--- a/.modify_schedule.php
+++ b/.modify_schedule.php
@@ -24,12 +24,13 @@ if (checkIfAdmin($connection)){
 
   foreach($weeks as $w) {
     foreach($post['data'][$w] as $elem) {
-      $sql = "UPDATE crews SET cc=:cc, driver=:driver, attendant=:attendant, observer=:observer WHERE id=:id";
+      $sql = "UPDATE crews SET cc=:cc, driver=:driver, attendant=:attendant, observer=:observer, dutysup=:dutysup WHERE id=:id";
       $statement = $connection->prepare($sql);
       $statement->bindValue(':cc', $elem["spots"]["cc"]["id"]);
       $statement->bindValue(':driver', $elem["spots"]["driver"]["id"]);
       $statement->bindValue(':attendant', $elem["spots"]["attendant"]["id"]);
       $statement->bindValue(':observer', $elem["spots"]["observer"]["id"]);
+      $statement->bindValue(':dutysup', $elem["spots"]["dutysup"]["id"]);
       $statement->bindValue(':id', $elem['id']);
       $result = $statement->execute();
     }

--- a/js/controllers/EditDefaultCtrl.js
+++ b/js/controllers/EditDefaultCtrl.js
@@ -5,7 +5,7 @@ angular.module('EditDefaultCtrl', []).controller('EditDefaultCtrl', ['$scope', '
     ];
 
     $scope.roles = [
-        'cc', 'driver', 'attendant', 'observer'
+        'cc', 'driver', 'attendant', 'observer', 'dutysup'
     ];
 
     $scope.changeMade = function () {
@@ -30,6 +30,8 @@ angular.module('EditDefaultCtrl', []).controller('EditDefaultCtrl', ['$scope', '
             return $scope.defaultSchedule[day]['cc'] == member.id || member.crewchief == 1 || member.cctrainer == 1 || member.backupcc == 1 || member.firstresponsecc == 1;
         } else if(role == 'driver') {
             return $scope.defaultSchedule[day]['driver'] == member.id || member.driver == 1 || member.drivertrainer == 1 || member.backupdriver == 1;
+        } else if(role == 'dutysup') {
+            return $scope.defaultSchedule[day]['dutysup'] == member.id || member.dutysup == 1;
         } else {
             return member.attendant == 1 || member.observer == 1
         }

--- a/js/controllers/ModifyScheduleCtrl.js
+++ b/js/controllers/ModifyScheduleCtrl.js
@@ -48,35 +48,6 @@ angular.module(ctrl_name, []).controller(ctrl_name, ['$scope', '$http', '$q', 'A
     };
     $scope.load();
 
-    $scope.loadCrews = function() {
-        if(!AuthService.getSessionId()) {
-            $location.url('/login');
-            return;
-        }
-
-        $scope.loadedCrews = false;
-        $http({
-            method: 'POST',
-            url: '.crews.php',
-            data: "session_id=" + AuthService.getSessionId() + "&view_date=" + DateService.formatViewDate($scope.viewDateWeek),
-            headers: {'Content-Type': 'application/x-www-form-urlencoded'}
-        }).then(function (response) {
-            console.log(response);
-            if (!response.data.success) {
-                console.log("it failed!");
-                console.log(response.data);
-            } else {
-                // Since the crews come in order of latest first, we need to separate
-                // them in a way that almost seems backwards.
-                $scope.tableHeadings = response.data.headings;
-                $scope.crews = response.data.crews;
-                $scope.positions = response.data.positions;
-                $scope.loadedCrews = true;
-            }
-        });
-    };
-
-
     $scope.determineEligibility = function(position, member, crew) {
         for(var i = 0; i < $scope.positions.length; i++) {
             if($scope.positions[i] == position) continue;

--- a/js/controllers/ModifyScheduleCtrl.js
+++ b/js/controllers/ModifyScheduleCtrl.js
@@ -48,6 +48,35 @@ angular.module(ctrl_name, []).controller(ctrl_name, ['$scope', '$http', '$q', 'A
     };
     $scope.load();
 
+    $scope.loadCrews = function() {
+        if(!AuthService.getSessionId()) {
+            $location.url('/login');
+            return;
+        }
+
+        $scope.loadedCrews = false;
+        $http({
+            method: 'POST',
+            url: '.crews.php',
+            data: "session_id=" + AuthService.getSessionId() + "&view_date=" + DateService.formatViewDate($scope.viewDateWeek),
+            headers: {'Content-Type': 'application/x-www-form-urlencoded'}
+        }).then(function (response) {
+            console.log(response);
+            if (!response.data.success) {
+                console.log("it failed!");
+                console.log(response.data);
+            } else {
+                // Since the crews come in order of latest first, we need to separate
+                // them in a way that almost seems backwards.
+                $scope.tableHeadings = response.data.headings;
+                $scope.crews = response.data.crews;
+                $scope.positions = response.data.positions;
+                $scope.loadedCrews = true;
+            }
+        });
+    };
+
+
     $scope.determineEligibility = function(position, member, crew) {
         for(var i = 0; i < $scope.positions.length; i++) {
             if($scope.positions[i] == position) continue;

--- a/js/controllers/ModifyScheduleCtrl.js
+++ b/js/controllers/ModifyScheduleCtrl.js
@@ -59,6 +59,8 @@ angular.module(ctrl_name, []).controller(ctrl_name, ['$scope', '$http', '$q', 'A
             return member.crewchief == 1 || member.firstresponsecc == 1 || member.cctrainer == 1 || member.backupcc == 1;
         } else if(position == 'driver') {
             return member.driver == 1 || member.drivertrainer == 1 || member.backupdriver == 1;
+        } else if(position == 'dutysup') {
+            return member.dutysup == 1;
         } else if(position == 'attendant' || position == 'observer') {
             return true;
         }

--- a/js/controllers/ModifyScheduleCtrl.js
+++ b/js/controllers/ModifyScheduleCtrl.js
@@ -51,7 +51,7 @@ angular.module(ctrl_name, []).controller(ctrl_name, ['$scope', '$http', '$q', 'A
     $scope.determineEligibility = function(position, member, crew) {
         for(var i = 0; i < $scope.positions.length; i++) {
             if($scope.positions[i] == position) continue;
-
+            if(position == 'dutysup' || $scope.positions[i] == 'dutysup') continue;
             if(crew.spots[$scope.positions[i]].id == member.id) return false;
         }
 

--- a/js/controllers/NightCrewsCtrl.js
+++ b/js/controllers/NightCrewsCtrl.js
@@ -43,7 +43,7 @@ angular.module('NightCrewsCtrl', []).controller('NightCrewsCtrl', ['$scope', '$f
         $scope.driver = data.driver == 1;
         $scope.drivertrainer = data.drivertrainer == 1;
         $scope.dob = data.dob;
-        $scope.loadCrewsNoDS();
+        $scope.loadCrews();
     }, function (error) {
         $location.url('/login');
     });
@@ -72,7 +72,7 @@ angular.module('NightCrewsCtrl', []).controller('NightCrewsCtrl', ['$scope', '$f
         $scope.tables.push({attribute: 'nextWeek', title: 'Week of ' + DateService.formatViewDate($scope.viewDateNextWeek)});
     }
 
-    $scope.loadCrewsNoDS = function() {
+    $scope.loadCrews = function() {
         if(!AuthService.getSessionId()) {
             $location.url('/login');
             return;
@@ -90,10 +90,6 @@ angular.module('NightCrewsCtrl', []).controller('NightCrewsCtrl', ['$scope', '$f
                 console.log("it failed!");
                 console.log(response.data);
             } else {
-                // Remove the Duty Supervisor from the data heading to the
-                // Night Crews page
-                response.data.headings.pop();
-                response.data.positions.pop();
                 // Since the crews come in order of latest first, we need to separate
                 // them in a way that almost seems backwards.
                 $scope.tableHeadings = response.data.headings;

--- a/js/controllers/NightCrewsCtrl.js
+++ b/js/controllers/NightCrewsCtrl.js
@@ -72,7 +72,7 @@ angular.module('NightCrewsCtrl', []).controller('NightCrewsCtrl', ['$scope', '$f
         $scope.tables.push({attribute: 'nextWeek', title: 'Week of ' + DateService.formatViewDate($scope.viewDateNextWeek)});
     }
 
-    $scope.loadCrews = function() {
+    $scope.loadCrewsNoDS = function() {
         if(!AuthService.getSessionId()) {
             $location.url('/login');
             return;
@@ -90,6 +90,10 @@ angular.module('NightCrewsCtrl', []).controller('NightCrewsCtrl', ['$scope', '$f
                 console.log("it failed!");
                 console.log(response.data);
             } else {
+                // Remove the Duty Supervisor from the data heading to the
+                // Night Crews page
+                response.data.headings.pop();
+                response.data.positions.pop();
                 // Since the crews come in order of latest first, we need to separate
                 // them in a way that almost seems backwards.
                 $scope.tableHeadings = response.data.headings;

--- a/js/controllers/NightCrewsCtrl.js
+++ b/js/controllers/NightCrewsCtrl.js
@@ -43,7 +43,7 @@ angular.module('NightCrewsCtrl', []).controller('NightCrewsCtrl', ['$scope', '$f
         $scope.driver = data.driver == 1;
         $scope.drivertrainer = data.drivertrainer == 1;
         $scope.dob = data.dob;
-        $scope.loadCrews();
+        $scope.loadCrewsNoDS();
     }, function (error) {
         $location.url('/login');
     });

--- a/slack-whoson.php
+++ b/slack-whoson.php
@@ -39,9 +39,14 @@ function getCrew($connection, $date) {
   $statement->execute();
   $attendant2 = $statement->fetchAll(PDO::FETCH_ASSOC);
 
+  $statement = $connection->query("SELECT first_name, last_name, radionum FROM members WHERE id = (SELECT dutysup FROM crews WHERE date = '$date')");
+  $statement->execute();
+  $dutysup = $statement->fetchAll(PDO::FETCH_ASSOC);
+
   return (cleanName($cc) == "OOS") ? "OUT OF SERVICE" : "Crew chief: " . cleanName($cc) . "\n" .
   "Driver: " . cleanName($driver) . "\n" .
-  "Attendants: " . cleanName($attendant1) . " and " . cleanName($attendant2);
+  "Attendants: " . cleanName($attendant1) . " and " . cleanName($attendant2) . "\n" .
+  "Duty supervisor: " . cleanName($dutysup);
 
 }
 

--- a/views/edit-default.html
+++ b/views/edit-default.html
@@ -21,6 +21,7 @@
                     <th>Driver</th>
                     <th>Rider</th>
                     <th>Rider</th>
+                    <th>Duty Supervisor</th>
                 </tr>
             </thead>
             <tbody>

--- a/views/modify-schedule.html
+++ b/views/modify-schedule.html
@@ -10,7 +10,7 @@
             <table class="table table-bordered table-striped">
                 <thead>
                 <tr>
-                    <th ng-repeat="th in tableHeadings track by $index" width="16%">
+                    <th ng-repeat="th in tableHeadings track by $index">
                         {{th}}
                     </th>
                 </tr>

--- a/views/night-crews.html
+++ b/views/night-crews.html
@@ -1,12 +1,12 @@
 <section id="NightCrews">
     <div class="container">
         <div class="row center" ng-repeat="t in tables">
-            <button class="btn btn-default btn-sm pull-right" ng-disabled="!loadedCrews" ng-click="loadCrewsNoDS()"><span class="fa fa-refresh"></span></button>
+            <button class="btn btn-default btn-sm pull-right" ng-disabled="!loadedCrews" ng-click="loadCrews()"><span class="fa fa-refresh"></span></button>
             <h2>{{t.title}}</h2>
             <table class="table table-bordered table-striped">
                 <thead>
                 <tr>
-                    <th ng-repeat="th in tableHeadings track by $index" width="16%">
+                    <th ng-repeat="th in tableHeadings | filter : '!Duty Supervisor' track by $index" width="16%">
                         {{th}}
                     </th>
                 </tr>
@@ -15,7 +15,7 @@
                 <tr ng-repeat="c in crews[t.attribute]" ng-attr-id="{{c.date === dateString ? 'current-day' : ''}}">
                     <td>{{c.day}}</td>
                     <td class="crew-date">{{c.date | date:'shortDate'}}</td>
-                    <td ng-repeat='p in positions'>
+                    <td ng-repeat='p in positions | filter : "!dutysup"'>
                         <span ng-if="c.spots[p]" title="{{c.spots[p].first_name}} {{c.spots[p].last_name}}">
                             <a ng-if="c.spots[p].email" ng-href="mailto:{{c.spots[p].email}}">{{c.spots[p].name}}</a>
                             <strong ng-if="!c.spots[p].email">{{c.spots[p].name}}</strong>

--- a/views/night-crews.html
+++ b/views/night-crews.html
@@ -1,7 +1,7 @@
 <section id="NightCrews">
     <div class="container">
         <div class="row center" ng-repeat="t in tables">
-            <button class="btn btn-default btn-sm pull-right" ng-disabled="!loadedCrews" ng-click="loadCrews()"><span class="fa fa-refresh"></span></button>
+            <button class="btn btn-default btn-sm pull-right" ng-disabled="!loadedCrews" ng-click="loadCrewsNoDS()"><span class="fa fa-refresh"></span></button>
             <h2>{{t.title}}</h2>
             <table class="table table-bordered table-striped">
                 <thead>


### PR DESCRIPTION
This adds a `dutysup` row to the `crews` table and the `default_crews` table in the database. It also adjusts the `Modify Schedule` and `Edit Default Schedule` pages on the website to show a column for Duty Supervisor.

Since `js/controllers/NightCrewsCtrl.js` and `js/controllers/ModifyScheduleCtrl.js` both used the same `loadCrews()` function to display the crew, the DS was appearing on the Night Crews page, I added a second function `loadCrewsNoDS` that removes the DS column from the Night Crews Page. Alternatively, it could be removed when being displayed, leaving it in the array, which would only require one function. Let me know if you think that'd be better!