### PR TITLE
Fix coordinator functionality in edit member page

### DIFF
--- a/.edit_member.php
+++ b/.edit_member.php
@@ -16,7 +16,7 @@ $modifiableFields = array(
   "secondlt", "schedco", "radioco", "traincommchair", "dutysup", "ees",
   "cctrainer", "drivertrainer", "firstresponsecc", "crewchief", "driver",
   "backupcc", "backupdriver", "clearedcc", "cleareddriver", "attendant", "observer", "active",
-  "access_revoked"
+  "access_revoked", "cprco", "webmaster", "qaco", "devco"
 );
 
 if($_SERVER['REQUEST_METHOD'] === 'POST') {

--- a/js/controllers/EditMemberCtrl.js
+++ b/js/controllers/EditMemberCtrl.js
@@ -217,10 +217,6 @@ angular.module('EditMemberCtrl', []).controller('EditMemberCtrl', ['$scope', '$h
             member.access_revoked = 0;
         }
 
-        if(member.admin == 1 && member.captain == 0) {
-            member.webmaster = '1';
-        }
-
         for (var j = 0; j < $scope.positions.length; j++) {
             if(member[$scope.positions[j].field] == 1) {
                 member.position = $scope.positions[j].field;
@@ -264,6 +260,7 @@ angular.module('EditMemberCtrl', []).controller('EditMemberCtrl', ['$scope', '$h
         } else if(toSubmit.position === 'webmaster') {
             toSubmit.admin = '1';
             toSubmit.captain = '0';
+            toSubmit.webmaster = '1';
         } else if(toSubmit.position === 'NoNe1') {
           for (var i = 1; i<$scope.positions.length; i++){
             toSubmit[$scope.positions[i].field] = '0'

--- a/js/controllers/EditMemberCtrl.js
+++ b/js/controllers/EditMemberCtrl.js
@@ -254,14 +254,7 @@ angular.module('EditMemberCtrl', []).controller('EditMemberCtrl', ['$scope', '$h
 
         console.log("TS2", toSubmit);
 
-        if (toSubmit.admin == '0' && toSubmit.position === 'webmaster'){
-            toSubmit.admin = '0';
-            toSubmit.position = '0';
-        } else if(toSubmit.position === 'webmaster') {
-            toSubmit.admin = '1';
-            toSubmit.captain = '0';
-            toSubmit.webmaster = '1';
-        } else if(toSubmit.position === 'NoNe1') {
+        if(toSubmit.position === 'NoNe1') {
           for (var i = 1; i<$scope.positions.length; i++){
             toSubmit[$scope.positions[i].field] = '0'
           }

--- a/js/controllers/MemberListCtrl.js
+++ b/js/controllers/MemberListCtrl.js
@@ -71,7 +71,7 @@ angular.module('MemberListCtrl', []).controller('MemberListCtrl', ['$scope', '$h
             email = "qa@rpiambulance.com";
         }else if (member_with_position.devco == 1){
             email = "dev@rpiambulance.com";
-        }else if (member_with_position.admin == 1){
+        }else if (member_with_position.webmaster == 1){
             email = "webmaster@rpiambulance.com";
         }else{
             email = member_with_position.email;
@@ -91,7 +91,7 @@ angular.module('MemberListCtrl', []).controller('MemberListCtrl', ['$scope', '$h
                 $scope.lineSide.push(elem);
             } else if(elem.pres == 1 || elem.vicepres == 1) {
                 $scope.civilSide.push(elem);
-            } else if(elem.devco == 1 || elem.qaco == 1 || elem.cprco == 1 || elem.radioco == 1 || elem.traincommchair == 1 || elem.schedco == 1 || ((elem.admin == 1) && (elem.captain == 0))) {
+            } else if(elem.devco == 1 || elem.qaco == 1 || elem.cprco == 1 || elem.radioco == 1 || elem.traincommchair == 1 || elem.schedco == 1 || elem.webmaster == 1) {
                 $scope.otherOfficers.push(elem);
             }
         });
@@ -115,7 +115,7 @@ angular.module('MemberListCtrl', []).controller('MemberListCtrl', ['$scope', '$h
             if (elem.devco == 1) {
               elem.card_id.push("Dev Team Coordinator");
             }
-            if (elem.admin == 1 && (!(elem.captain == 1 || elem.traincommchair == 1 || elem.qaco == 1))) {
+            if (elem.webmaster == 1) {
                 elem.card_id.push("Webmaster");
             }
             if (elem.radioid == 0){


### PR DESCRIPTION
As it is now, the edit member page on the website cannot add/remove some of the coordinator positions, even though they're listed in the dropdown (CPR Coordinator, QA/QI Coordinator, Dev Team Coordinator, Webmaster). This fixes that, as well as decoupling the Webmaster position from being an admin on the website. The Webmaster position would be added and removed as any other position, instead of  being shown on any member who is a website admin that doesn't hold any other officer/coordinator position in the agency (as it does now).