### PR TITLE
Fix changing of coordinators in edit member page

### DIFF
--- a/.edit_member.php
+++ b/.edit_member.php
@@ -16,7 +16,7 @@ $modifiableFields = array(
   "secondlt", "schedco", "radioco", "traincommchair", "dutysup", "ees",
   "cctrainer", "drivertrainer", "firstresponsecc", "crewchief", "driver",
   "backupcc", "backupdriver", "clearedcc", "cleareddriver", "attendant", "observer", "active",
-  "access_revoked, cprco, webmaster, qaco, devco"
+  "access_revoked", "cprco", "webmaster", "qaco", "devco"
 );
 
 if($_SERVER['REQUEST_METHOD'] === 'POST') {

--- a/.edit_member.php
+++ b/.edit_member.php
@@ -16,7 +16,7 @@ $modifiableFields = array(
   "secondlt", "schedco", "radioco", "traincommchair", "dutysup", "ees",
   "cctrainer", "drivertrainer", "firstresponsecc", "crewchief", "driver",
   "backupcc", "backupdriver", "clearedcc", "cleareddriver", "attendant", "observer", "active",
-  "access_revoked"
+  "access_revoked, cprco, webmaster, qaco, devco"
 );
 
 if($_SERVER['REQUEST_METHOD'] === 'POST') {


### PR DESCRIPTION
This will allow for adding/removing the previously broken coordinator positions (CPR, Webmaster, QA/QI, and Dev Team). Webmaster is still also tied into website Admin status (any non-officer/coordinator with full admin on the website will be shown as a webmaster).