### PR TITLE
Full CC/Driver doesn't need CC-T on to sign up

### DIFF
--- a/.crews.php
+++ b/.crews.php
@@ -59,14 +59,14 @@ function determineEligibility ($member, $pos, $i, $ontoday, $onthisweek, $ccton,
 
     if($pos == 'cc') {
         $condition3 = $member['crewchief'] == 1 || $member['firstresponsecc'] == 1 || $member['cctrainer'] == 1;
-        if ($member['backupcc'] == 1) {
+        if ($member['backupcc'] == 1 && $condition3  == 0) {
             return [$ccton[$i] == 1, 'No CC-T on'];
         } else {
             return [$condition3, 'CC credential required'];
         }
     } else if($pos == 'driver') {
         $condition3 = $member['driver'] == 1 || $member['drivertrainer'] == 1;
-        if ($member['backupdriver'] == 1) {
+        if ($member['backupdriver'] == 1 && $condition3  == 0) {
             return [$dton[$i] == 1, 'No D-T on'];
         } else {
             return [$condition3, 'Driver credential required'];


### PR DESCRIPTION
The P-CC/P-D check for a trainer was overriding a member's higher (CC, CC-T, FR-CC, D, D-T) credential if they still had the probationary position checked. It would show them "No [CC/D]-T on" and prevent them from signing up if they had both the probationary and the higher position.