### PR TITLE
Fix event datepicker

### DIFF
--- a/js/controllers/AddEventCtrl.js
+++ b/js/controllers/AddEventCtrl.js
@@ -11,7 +11,6 @@ angular.module(ctrl_name, []).controller(ctrl_name, ['$scope', '$http', '$locati
   $scope.datepicker = {
     options: {
       formatYear: 'yy',
-      maxDate: new Date(2020, 5, 22),
       minDate: new Date(),
       startingDay: 0
     },


### PR DESCRIPTION
The datepicker for creating and editing events had a maxDate set which only allowed users to select dates before 2020-05-22. Dates beyond then could be manually entered, but not selected via the popup. This removes the maxDate and allows selection of any date.