### PR TITLE
add check for which week is being worked on

### DIFF
--- a/.crews.php
+++ b/.crews.php
@@ -279,7 +279,13 @@ function main () {
             $statement->execute();
             $member = $statement->fetchAll(PDO::FETCH_ASSOC)[0];
 
-            for ($x = -7; $x < 7; $x++) { //Start this at -7 for 2-week rotation, and 0 for 1-week
+            if ($tableloop == 0) {
+                $endLoopValue = 14;
+            } else if ($tableloop == 1) {
+                $endLoopValue = 7;
+            }
+
+            for ($x = -7; $x < $endLoopValue; $x++) { //Start this at -7 for 2-week rotation, and 0 for 1-week
                 $ontoday[$x] = 0;
                 $ccton[$x]   = 0;
                 $dton[$x]    = 0;

--- a/.crews.php
+++ b/.crews.php
@@ -279,13 +279,22 @@ function main () {
             $statement->execute();
             $member = $statement->fetchAll(PDO::FETCH_ASSOC)[0];
 
+            $twoWeekRotation = true; //set this as false if you want a one-week rotation
+
+            $startLoopValue = -7;
+
             if ($tableloop == 0) {
                 $endLoopValue = 14;
             } else if ($tableloop == 1) {
                 $endLoopValue = 7;
             }
 
-            for ($x = -7; $x < $endLoopValue; $x++) { //Start this at -7 for 2-week rotation, and 0 for 1-week
+            if ($twoWeekRotation == false) {
+                $startLoopValue = 0;
+                $endLoopValue = 7;
+            }
+
+            for ($x = $startLoopValue; $x < $endLoopValue; $x++) {
                 $ontoday[$x] = 0;
                 $ccton[$x]   = 0;
                 $dton[$x]    = 0;


### PR DESCRIPTION
This fixes the issue that was discussed in #110 but wouldn't have been fixed with just changing `7` to `14`.

Basically, `$tableloop` is `0` or `1` depending on which week is being modified. That is, if you're trying to sign up for a night crew _this week_, `$tableloop` will be `0`, and day `0` is indexed to the Sunday of this week. In that case, we want to look _forward_ to the end of _next week_ to ensure you're not riding so as to enforce the "every two week" policy that's currently in place. ~Note that this code will have to be changed if/when that policy is reverted to "every week."~ I also added a boolean for a two- vs. one-week rotation.

Conversely, if you're trying to sign up for a crew _next week_, `$tableloop` is `1`, and day `0` is indexed to the Sunday of next week. As such, we only want to look forward seven days, which, yes, still gets you to the end of next week. If you were to use `14` as was coded in #110, you'll end up at the end of the following week, which doesn't exist in the database yet.

I hope that makes sense. It only took about an hour of walking through the code to figure out what was going on. tbh we're still not entirely sure 🤞 