### PR TITLE
Fixing Dead Links

### DIFF
--- a/index.html
+++ b/index.html
@@ -285,7 +285,7 @@
                 </li>
                 <li><a href="http://www.remo-ems.com/">REMO</a></li>
                 <li>
-                  <a href="http://www.rensco.com/departments/public-safety/"
+                  <a href="https://www.rensco.com/276/Public-Safety/"
                     >Rensselaer County</a
                   >
                 </li>

--- a/js/controllers/DOHResourcesCtrl.js
+++ b/js/controllers/DOHResourcesCtrl.js
@@ -5,8 +5,8 @@ angular.module(ctrl_name, []).controller(ctrl_name, ['$scope', function($scope) 
         {
             header: '',
             internal_title: 'Links',
-            body: '* [Meeting Minutes of the State EMS Council (SEMSCO)](http://www.saratogaems.org/NYS_EMS_Council.htm)' +
-            ' - Meeting minutes of the State EMS Council as prepared (humorously) by Mike McEvoy (EMS Coordinator for ' +
+            body: '* [Meeting Minutes of the Saratoga EMS Council (SEMSCO)](https://saratogaems.org/news-announcements/nys-ems-news/)' +
+            ' - Meeting minutes of the Saratoga EMS Council as prepared (humorously) by Mike McEvoy (EMS Coordinator for ' +
             'Saratoga County). Good to read these to know what is going on with EMS in the state. Our protocols and ' +
             'policies originate from the council.\n' +
 
@@ -25,7 +25,7 @@ angular.module(ctrl_name, []).controller(ctrl_name, ['$scope', function($scope) 
             '[New York State Sanitary Code PART - 18](http://www.health.ny.gov/nysdoh/ems/part18.htm) - New York State ' +
             'laws regarding medical coverage for public events and large gatherings.\n' +
 
-            '* [State Emergency Medical Services Code- Part 800](http://www.health.ny.gov/nysdoh/ems/part800.htm) - New ' +
+            '* [State Emergency Medical Services Code- Part 800](https://regs.health.ny.gov/volume-e-title-10/200443669/part-800-emergency-medical-services) - New ' +
             'York State laws regarding the qualifications of EMS providers and instructors as well as the requirements ' +
             'for ambulances and other support vehicles.\n' +
 

--- a/js/controllers/DOHResourcesCtrl.js
+++ b/js/controllers/DOHResourcesCtrl.js
@@ -5,8 +5,8 @@ angular.module(ctrl_name, []).controller(ctrl_name, ['$scope', function($scope) 
         {
             header: '',
             internal_title: 'Links',
-            body: '* [Meeting Minutes of the Saratoga EMS Council (SEMSCO)](https://saratogaems.org/news-announcements/nys-ems-news/)' +
-            ' - Meeting minutes of the Saratoga EMS Council as prepared (humorously) by Mike McEvoy (EMS Coordinator for ' +
+            body: '* [Meeting Minutes of the State EMS Council (SEMSCO)](https://saratogaems.org/news-announcements/nys-ems-news/)' +
+            ' - Meeting minutes of the State EMS Council as prepared (humorously) by Mike McEvoy (EMS Coordinator for ' +
             'Saratoga County). Good to read these to know what is going on with EMS in the state. Our protocols and ' +
             'policies originate from the council.\n' +
 

--- a/js/controllers/FAQCtrl.js
+++ b/js/controllers/FAQCtrl.js
@@ -48,7 +48,7 @@ angular.module('FAQCtrl', []).controller('FAQCtrl', ['$scope', '$sce', function 
             header: 'I am an EMT but am not a New York State EMT. What now?',
             body: 'Great! We can get you information ' +
             'on who to contact to apply for reciprocity and have your certification carry over to New York State. For ' +
-            'information, please contact one of the officers and see the <a href="EMT-reciprocity.html">NYS EMS Reciprocity</a> ' +
+            'information, please contact one of the officers and see the <a href="https://www.health.ny.gov/professionals/ems/certification/reciprocity.htm">NYS EMS Reciprocity</a> ' +
             'page.'
         },
         {

--- a/js/controllers/RENSCOResourcesCtrl.js
+++ b/js/controllers/RENSCOResourcesCtrl.js
@@ -5,16 +5,14 @@ angular.module(ctrl_name, []).controller(ctrl_name, ['$scope', function($scope) 
         {
             header: '',
             internal_title: 'Links',
-            body: '* [Rensselaer County Communications Committee](http://sites.google.com/site/rensselaercountycommunications/)' +
-            ' - Meeting minutes of the State EMS Council as prepared (humorously) by Mike McEvoy (EMS Coordinator for ' +
-            'Saratoga County). Good to read these to know what is going on with EMS in the state. Our protocols and ' +
-            'policies originate from the council.\n' +
+            body: '* [Rensselaer County Radio Committee](https://www.rensco.com/428/Radio-Committee)' +
+            ' - Homepage of the Rensselaer County Radio Committee, a group which advises the management of the County\'s Emergency Communications System.\n' +
 
             '* [Rensselaer County Ambulance and Rescue Association](http://www.rc-ara.org/) - Homepage of the New York ' +
             'State Department of Health Bureau of EMS. There is a lot of good information and documentation on the ' +
             'EMS system as whole in New York State.\n' +
 
-            '* [REMO EMS Protocols](http://www.remo-ems.com/remo/protocols.php) - Regional EMS protocols. (ALS and BLS)'
+            '* [REMO EMS Protocols](https://www.remo-ems.com/emergency-medical-services/protocols/) - Regional EMS protocols. (ALS and BLS)'
         },
 
         {

--- a/views/home.html
+++ b/views/home.html
@@ -151,7 +151,7 @@
           <li><a href="http://www.rpi.edu/dept/public_safety/"><img class="partner" data-wow-duration="1000ms" alt="RPI Public Safety Logo" title="RPI Public Safey" data-wow-delay="300ms" src="img/partners/new/pubsafe.svg"></a></li>
           <li><a href="http://studenthealth.rpi.edu/"><img class="partner" data-wow-duration="1000ms" alt="RPI Student Health Logo" title="RPI Student Health" data-wow-delay="600ms" src="img/partners/new/shc.svg"></a></li>
           <li><a href="http://www.remo-ems.com/"><img class="partner" data-wow-duration="1000ms" alt="REMO Logo" title="REMO" data-wow-delay="900ms" src="img/partners/new/remo.svg"></a></li>
-          <li><a href="http://www.rensco.com/departments/public-safety/"><img class="partner" data-wow-duration="1000ms" alt="RENSCO Logo" title="RENSCO" data-wow-delay="1200ms" src="img/partners/RENSCO.svg"></a></li>
+          <li><a href="https://www.rensco.com/276/Public-Safety/"><img class="partner" data-wow-duration="1000ms" alt="RENSCO Logo" title="RENSCO" data-wow-delay="1200ms" src="img/partners/RENSCO.svg"></a></li>
           <li><a href="http://www.troyny.gov/departments/fire-department/"><img class="partner" data-wow-duration="1000ms" alt="Troy Fire Department Logo" title="Troy Fire Department" data-wow-delay="1500ms" src="img/partners/new/tfd.svg"></a></li>
         </ul>
       </div>


### PR DESCRIPTION
Fixed a few dead links throughout the website:

The FAQ had a dead link which was supposed to point to information about reciprocity. As Tom pointed out that this page is more public-facing (members likely wouldn't be on the FAQ), I changed this link to the NYS reciprocity website instead of the member-only page on reciprocity.

The home page had two dead links to Rensselaer County Public Safety (one on the logo, another under "Other Agencies." Swapped these out.

The DOH Resources page had two dead links as well, swapped those out.

Finally, the Rensselaer County Resources page had a dead link as well as one that didn't seem to match the following description. Swapped that one out for a new link and altered the description.