### PR TITLE
Lock game attendance

### DIFF
--- a/.add_game.php
+++ b/.add_game.php
@@ -26,6 +26,7 @@ $end_time = $input['endstamp'];
 $date = $input['datestamp'];
 $type = $input['type'];
 $ees = 0;
+$locked = $input['locked'];
 $mode = $input['mode'];
 
 if($mode == 'edit') {
@@ -55,7 +56,7 @@ try {
 
     $logid = $statement->fetchAll(PDO::FETCH_ASSOC)[0]['max'] + 1;
 
-    $statement = $connection->prepare("INSERT INTO games(id, `date`, start, `end`, description, location, ees, hide) VALUES (:logid, :date, :start_time, :end_time, :event_name, :event_location, :ees, 0)");
+    $statement = $connection->prepare("INSERT INTO games(id, `date`, start, `end`, description, location, locked, ees, hide) VALUES (:logid, :date, :start_time, :end_time, :event_name, :event_location, 0, :ees, 0)");
 
     $statement->bindParam(":logid", $logid);
     $statement->bindParam(":date", $date);
@@ -73,6 +74,7 @@ try {
       `end`=:end_time,
       `description`=:event_name,
       `location`=:event_location,
+      `locked`=:locked,
       `hide`=0
     WHERE id=:id");
 
@@ -82,6 +84,7 @@ try {
     $statement->bindParam(":end_time", $end_time);
     $statement->bindParam(":event_name", $event_name);
     $statement->bindParam(":event_location", $event_location);
+    $statement->bindParam(":locked", $locked);
 
     $result = $statement->execute();
   }

--- a/.docker/mysql/schema.sql
+++ b/.docker/mysql/schema.sql
@@ -124,6 +124,7 @@ CREATE TABLE `games` (
   `end` time NOT NULL DEFAULT '00:00:00',
   `description` text NOT NULL,
   `location` text NOT NULL,
+  `locked` tinyint(1) NOT NULL DEFAULT '0',
   `ees` tinyint(1) NOT NULL DEFAULT '0',
   `hide` tinyint(1) NOT NULL,
   `gcalEventId` VARCHAR(255) DEFAULT NULL

--- a/js/controllers/AddEventCtrl.js
+++ b/js/controllers/AddEventCtrl.js
@@ -42,7 +42,8 @@ angular.module(ctrl_name, []).controller(ctrl_name, ['$scope', '$http', '$locati
       end_time: "",
       date: "",
       type: "",
-      limit: ""
+      limit: "",
+      locked: ""
   };
 
   function parseDateString(string) {
@@ -81,6 +82,7 @@ angular.module(ctrl_name, []).controller(ctrl_name, ['$scope', '$http', '$locati
                   $scope.formData.date = parseDateString(response.data.event.date);
                   $scope.formData.type = "1";
                   $scope.formData.limit = parseInt(response.data.event.limit);
+                  $scope.formData.locked = "-1";
               }
           });
 
@@ -106,6 +108,7 @@ angular.module(ctrl_name, []).controller(ctrl_name, ['$scope', '$http', '$locati
                   } else {
                     $scope.formData.type = "2";
                   }
+                  $scope.formData.locked = response.data.game.locked;
               }
           });
     }

--- a/js/controllers/GameCtrl.js
+++ b/js/controllers/GameCtrl.js
@@ -25,6 +25,7 @@ angular.module(ctrl_name, []).controller(ctrl_name, ['$scope', '$http', '$httpPa
                 console.log(response.data);
                 $scope.attendees = response.data.attendees;
                 $scope.game = response.data.game;
+                $scope.locked = response.data.game.locked;
                 $scope.alreadySignedUp = response.data.alreadySignedUp;
                 $scope.eligiblePositions = response.data.eligiblePositions;
                 $scope.currentPosition = response.data.currentPosition;
@@ -73,7 +74,7 @@ angular.module(ctrl_name, []).controller(ctrl_name, ['$scope', '$http', '$httpPa
     $scope.load();
 
     $scope.signup = function (position) {
-        if ($scope.alreadySignedUp && $scope.currentPosition === position) {
+        if (($scope.alreadySignedUp && $scope.currentPosition === position) || $scope.locked === '1') {
             return;
         }
 

--- a/views/add-event.html
+++ b/views/add-event.html
@@ -54,6 +54,11 @@
                             </p>
                         </div>
 
+                        <div class="form-group col-xs-6 fixed-height-form-element" ng-if="editMode && formData.type != 1">
+                            <label for="locked">Lock Game</label>
+                            <input type="checkbox" name="locked" id="locked" class="form-control" ng-model="formData.locked" ng-true-value="'1'" ng-false-value="'0'" ng-checed="formData.locked" />
+                        </div>
+
                         <div class="form-group col-xs-6 fixed-height-form-element" ng-if="!editMode">
                             <label for="type">Event Type</label>
                             <select class="form-control" id="type" ng-model="formData.type">
@@ -70,11 +75,6 @@
                             <input type="number" name="lim" id="lim" class="form-control" ng-model="formData.limit" min="-1"
                                    placeholder="0 for no limit, -1 for no signups" required/>
                            <p class="help-block text-small">Note: Games do not have a specifiable limit.</p>
-                        </div>
-
-                        <div class="form-group col-xs-6 fixed-height-form-element" ng-if="editMode && formData.type != 1">
-                            <label for="locked">Lock Game</label>
-                            <input type="checkbox" name="locked" id="locked" class="form-control" ng-model="formData.locked" ng-true-value="'1'" ng-false-value="'0'" ng-checed="formData.locked" />
                         </div>
 
                         <div class="form-group col-xs-6 fixed-height-form-element" ng-if="!editMode && (!formData.type || formData.type == 1)"></div>

--- a/views/add-event.html
+++ b/views/add-event.html
@@ -54,11 +54,6 @@
                             </p>
                         </div>
 
-                        <div class="form-group col-xs-6 fixed-height-form-element" ng-if="editMode && formData.type != 1">
-                            <label for="locked">Lock Game</label>
-                            <input type="checkbox" name="locked" id="locked" class="form-control" ng-model="formData.locked" ng-true-value="'1'" ng-false-value="'0'" ng-checed="formData.locked" />
-                        </div>
-
                         <div class="form-group col-xs-6 fixed-height-form-element" ng-if="!editMode">
                             <label for="type">Event Type</label>
                             <select class="form-control" id="type" ng-model="formData.type">
@@ -68,7 +63,11 @@
                                 <option value="3">Game (NO EES)</option>
                             </select>
                         </div>
-                        <div class="form-group col-xs-6 fixed-height-form-element" ng-if="editMode && formData.type != 1"></div>
+
+                        <div class="form-group col-xs-6 fixed-height-form-element" ng-if="editMode && formData.type != 1">
+                            <label for="locked">Lock Game</label>
+                            <input type="checkbox" name="locked" id="locked" class="form-control" ng-model="formData.locked" ng-true-value="'1'" ng-false-value="'0'" ng-checed="formData.locked" />
+                        </div>
 
                         <div class="form-group col-xs-6 fixed-height-form-element" ng-if="!formData.type || formData.type == 1">
                             <label for="lim">Attendance Limit</label>

--- a/views/add-event.html
+++ b/views/add-event.html
@@ -66,7 +66,7 @@
 
                         <div class="form-group col-xs-6 fixed-height-form-element" ng-if="editMode && formData.type != 1">
                             <label for="locked">Lock Game</label>
-                            <input type="checkbox" name="locked" id="locked" class="form-control" ng-model="formData.locked" ng-true-value="'1'" ng-false-value="'0'" ng-checed="formData.locked" />
+                            <input type="checkbox" name="locked" id="locked" class="form-control" ng-model="formData.locked" ng-true-value="'1'" ng-false-value="'0'" ng-checed="formData.locked" style="margin: 0px; height: 32px"/>
                         </div>
 
                         <div class="form-group col-xs-6 fixed-height-form-element" ng-if="!formData.type || formData.type == 1">

--- a/views/add-event.html
+++ b/views/add-event.html
@@ -71,6 +71,12 @@
                                    placeholder="0 for no limit, -1 for no signups" required/>
                            <p class="help-block text-small">Note: Games do not have a specifiable limit.</p>
                         </div>
+
+                        <div class="form-group col-xs-6 fixed-height-form-element" ng-if="editMode && formData.type != 1">
+                            <label for="locked">Lock Game</label>
+                            <input type="checkbox" name="locked" id="locked" class="form-control" ng-model="formData.locked" ng-true-value="'1'" ng-false-value="'0'" ng-checed="formData.locked" />
+                        </div>
+
                         <div class="form-group col-xs-6 fixed-height-form-element" ng-if="!editMode && (!formData.type || formData.type == 1)"></div>
 
                         <div class="form-actions" ng-if="!editMode">

--- a/views/game.html
+++ b/views/game.html
@@ -53,7 +53,7 @@
                     <button class="btn btn-primary btn-lg" ng-if="alreadySignedUp" ng-click="drop()">
                         <span class="fa fa-minus"></span> Drop Game
                     </button>
-                    <button class="btn btn-primary btn-lg" ng-repeat="p in positions" ng-if="p.value !== currentPosition && eligiblePositions.indexOf(p.value) !== -1" ng-click="signup(p.value)">
+                    <button class="btn btn-primary btn-lg" ng-repeat="p in positions" ng-if="p.value !== currentPosition && eligiblePositions.indexOf(p.value) !== -1 && locked == '0'" ng-click="signup(p.value)">
                         <span class="fa fa-plus"></span>
                         <span ng-if="!alreadySignedUp">Sign up as</span>
                         <span ng-if="alreadySignedUp">Switch to</span>


### PR DESCRIPTION
### **Purpose**

Adds the ability to lock games (not events) from signups by editing the game on the calendar (request #163). This will prevent anybody from signing up or switching their role, but does allow people to drop from a locked game.

### **Deployment**

The following SQL statement will need to be run on the production DB to add the new column to the `games` table:
```
ALTER TABLE `games` ADD `locked` TINYINT(1) NOT NULL DEFAULT '0' AFTER `location`;
```
Here is a preview of what it looks like:

<p align="center">
 
<img width="500" alt="Screenshot 2023-12-09 at 10 23 38 PM" src="https://github.com/rpiambulance/website/assets/43799350/2357cb4f-706a-4cb5-9f1a-fe8fa7cbdc47">
</p>