### PR TITLE
CrewChiefTrainingCtrl breaks website

### DIFF
--- a/js/controllers/CrewChiefTrainingCtrl.js
+++ b/js/controllers/CrewChiefTrainingCtrl.js
@@ -41,7 +41,7 @@ angular.module(ctrl_name, []).controller(ctrl_name, ['$scope', function ($scope)
             '* Be a Probationary Crew Chief\n' +
             '* Crew Chief at least two (2) calls, one of which must be a transport, and receive a passing evaluation\n' +
             '* Lead a training drill, scenario, or other agency training event \n' +
-            '* Recieve joint approval from the captain and training committee
+            '* Recieve joint approval from the captain and training committee'
 
         },
 


### PR DESCRIPTION
A line in CrewChiefTrainingCtrl was missing a `'` causing the website to break/not load.

<img width="688" alt="image" src="https://github.com/rpiambulance/website/assets/29312937/d016205d-2666-4d7d-9c87-e356ac3e3282">